### PR TITLE
Allow piles cell align differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+- Add a new property called [`pileCellAlign`](DOCS.md#pilingsetproperty-value) to define where the piles are aligned to, which accepts the following values:
+  - 'topleft'
+  - 'topRight'
+  - 'bottomLeft'
+  - 'bottomRight'
+  - 'center'
 - Add properties for setting various colors via [`.set()`](DOCS.md#pilingsetproperty-value):
   - `backgroundColor`
   - `lassoFillColor`

--- a/DOCS.md
+++ b/DOCS.md
@@ -179,6 +179,7 @@ The list of all understood properties is given below.
 | pileBorderOpacityActive   | float            | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
 | pileBackgroundColor       | string or int    | `0x000000`            |                                                                               | `false`    |
 | pileBackgroundOpacity     | float            | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| pileCellAlign             | string           | `topLeft`         | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                       | `true`     |
 | pileContextMenuItems      | array            | `[]`                  | see _examples_ below                                                          | `true`     |
 | previewAggregator         | function         |                       | see [`aggregators`](#aggregators)                                             | `true`     |
 | previewRenderer           | function         |                       | see [`renderers`](#renderers)                                                 | `true`     |

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -50,7 +50,8 @@ const createMatrixPiles = async element => {
     previewAggregator: matrixPreviewAggregator,
     items: data,
     columns: 12,
-    itemPadding: 30
+    itemPadding: 30,
+    pileCellAlign: 'topRight'
   });
 
   return pilingJs;

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -14,6 +14,8 @@ const createPhotoPiles = async element => {
   piling.set('items', data);
   piling.set('itemPadding', 10);
 
+  piling.set('pileCellAlign', 'center');
+
   return piling;
 };
 

--- a/src/pile.js
+++ b/src/pile.js
@@ -42,6 +42,8 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
   let hasCover = false;
 
   let isPositioning = false;
+  let cX;
+  let cY;
 
   const pubSubSubscribers = [];
   let hoverItemSubscriber;
@@ -232,6 +234,8 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     bBox.minY = newBBox.minY;
     bBox.maxX = newBBox.maxX;
     bBox.maxY = newBBox.maxY;
+    cX = bBox.minX + (bBox.maxX - bBox.minX) / 2;
+    cY = bBox.minY + (bBox.maxY - bBox.minY) / 2;
   };
 
   const calcBBox = () => {
@@ -482,22 +486,30 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     itemsById.set(id, initialItem);
   };
 
+  const moveTo = (x, y) => {
+    if (!Number.isNaN(+x) && !Number.isNaN(+y)) {
+      graphics.x = x;
+      graphics.y = y;
+      updateBBox();
+    }
+  };
+
   init();
 
   return {
-    destroy,
-    drawBorder,
-    border,
-    itemsById,
-    newItemsById,
-    graphics,
-    itemContainer,
-    id,
-    bBox,
-    calcBBox,
-    updateBBox,
-    cover,
-    positionItems,
+    // Properties
+    get cX() {
+      return cX;
+    },
+    get cY() {
+      return cY;
+    },
+    get bBox() {
+      return bBox;
+    },
+    get graphics() {
+      return graphics;
+    },
     get hasCover() {
       return hasCover;
     },
@@ -516,9 +528,28 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     set isTempDepiled(newIsTempDepiled) {
       isTempDepiled = !!newIsTempDepiled;
     },
-    scale,
+    get x() {
+      return graphics.x;
+    },
+    get y() {
+      return graphics.y;
+    },
+    // Methods
+    animatePositionItems,
     animateScale,
-    animatePositionItems
+    border,
+    calcBBox,
+    cover,
+    destroy,
+    drawBorder,
+    id,
+    itemContainer,
+    itemsById,
+    moveTo,
+    newItemsById,
+    positionItems,
+    scale,
+    updateBBox
   };
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -190,6 +190,9 @@ const [pileBackgroundOpacity, setPileBackgroundOpacity] = setter(
   0.85
 );
 
+// 'topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'center'
+const [pileCellAlign, setPileCellAlign] = setter('pileCellAlign', 'topLeft');
+
 const [pileContextMenuItems, setPileContextMenuItems] = setter(
   'pileContextMenuItems',
   []
@@ -352,6 +355,7 @@ const createStore = () => {
     pileBorderOpacityActive,
     pileBackgroundColor,
     pileBackgroundOpacity,
+    pileCellAlign,
     pileContextMenuItems,
     piles,
     previewAggregator,
@@ -439,5 +443,6 @@ export const createAction = {
   setPileBorderOpacityActive,
   setPileBackgroundColor,
   setPileBackgroundOpacity,
+  setPileCellAlign,
   setPileContextMenuItems
 };


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add a property called `pileCellAlign`, which accepts the following values:
- topLeft
- topRight
- bottomLeft
- bottomRight
- center

> Why is it necessary?

The piles can be aligned to different positions in the cells. Align to `center` would be useful.

Fixes #61 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
