### PR TITLE
Flekschas/refactor clean grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Next
 
+## v0.4.2
+
+- Refactored the grid:
+  - `layout.cellWidth` is now called `layout.columnWidth`
+  - `layout.colWidth` is now called `layout.cellWidth`
+  - `layout.cellHeight` is now called `layout.rowHeight`
+  - `layout.rowHeight` is now called `layout.cellHeight`
+  - `layout.colNum` is now called `layout.numColumns`
+  - `layout.rowNum` is now called `layout.numRows`
+  - All properties but `layout.numRows` are read-only now
+- Simplified `resizeHandler()` and debounced it
+- Changed the default value of `itemSizeRange` from `[0.7, 0.9]` to `[0.5, 1.0]` to make full use of the cell width
+- Changed the default value of `itemPadding` from `0` to `6` to ensure some padding
+
 ## v0.4.1
 
 - Include ES modules in npm release

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -50,8 +50,7 @@ const createMatrixPiles = async element => {
     previewAggregator: matrixPreviewAggregator,
     items: data,
     columns: 12,
-    itemPadding: 30,
-    pileCellAlign: 'topRight'
+    pileCellAlign: 'center'
   });
 
   return pilingJs;

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -9,10 +9,9 @@ const createPhotoPiles = async element => {
 
   const piling = createPilingJs(element);
 
-  piling.set('itemSize', 300);
+  piling.set('itemSize', 160);
   piling.set('renderer', imageRenderer);
   piling.set('items', data);
-  piling.set('itemPadding', 10);
 
   piling.set('pileCellAlign', 'center');
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -24,15 +24,15 @@ const createGrid = (
 ) => {
   const { width } = canvas.getBoundingClientRect();
 
-  let colNum = columns;
-  let rowNum;
+  let numColumns = columns;
+  let numRows;
   let columnWidth = width / columns;
   let cellWidth = columnWidth - itemPadding * 2;
   let cellHeight = null;
 
   if (+itemSize) {
     columnWidth = itemSize + itemPadding * 2;
-    colNum = Math.floor(width / columnWidth);
+    numColumns = Math.floor(width / columnWidth);
     cellWidth = itemSize;
   }
 
@@ -56,14 +56,14 @@ const createGrid = (
    * @param   {number}  j  Position on the y-axis
    * @return  {number}  Index of the i,j-th cell
    */
-  const ijToIdx = (i, j) => j * colNum + i;
+  const ijToIdx = (i, j) => j * numColumns + i;
 
   /**
    * Convert an index to the i,j cell position
    * @param   {number}  idx  Index of a cell
    * @return  {array}  Tuple with the i,j cell position
    */
-  const idxToIj = idx => [idx % colNum, Math.floor(idx / colNum)];
+  const idxToIj = idx => [idx % numColumns, Math.floor(idx / numColumns)];
 
   /**
    * Convert the i,j cell position to an x,y pixel position
@@ -161,16 +161,17 @@ const createGrid = (
 
       // 2a. Determine anchor point. For that we check if the top, left, or right
       // cell is empty
-      const topIdx = idx - colNum;
+      const topIdx = idx - numColumns;
       const isTopBlocked = topIdx < 0 || (cells[topIdx] && cells[topIdx].size);
       const leftIdx = idx - 1;
       const isLeftBlocked =
         leftIdx < 0 ||
-        idx % colNum === 0 ||
+        idx % numColumns === 0 ||
         (cells[leftIdx] && cells[leftIdx].size);
       const rightIdx = idx + 1;
       const isRightBlocked =
-        rightIdx % colNum === 0 || (cells[rightIdx] && cells[rightIdx].size);
+        rightIdx % numColumns === 0 ||
+        (cells[rightIdx] && cells[rightIdx].size);
       let x = a => a;
       let y = a => a;
       if (isTopBlocked) {
@@ -267,14 +268,14 @@ const createGrid = (
     get itemSize() {
       return itemSize;
     },
-    get colNum() {
-      return colNum;
+    get numColumns() {
+      return numColumns;
     },
-    get rowNum() {
-      return rowNum;
+    get numRows() {
+      return numRows;
     },
-    set rowNum(newRowNum) {
-      if (!Number.isNaN(+newRowNum)) rowNum = newRowNum;
+    set numRows(newNumRows) {
+      if (!Number.isNaN(+newNumRows)) numRows = newNumRows;
     },
     get columnWidth() {
       return columnWidth;

--- a/src/library.js
+++ b/src/library.js
@@ -1674,7 +1674,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       // vertical lines
       for (let i = 1; i < vLineNum; i++) {
         gridGfx.moveTo(i * layout.columnWidth, 0);
-        gridGfx.lineTo(i * layout.rowWidth, height);
+        gridGfx.lineTo(i * layout.columnWidth, height);
       }
       // horizontal lines
       for (let i = 1; i < hLineNum; i++) {

--- a/src/library.js
+++ b/src/library.js
@@ -345,6 +345,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   let scaleSprite;
 
   const scaleItems = () => {
+    if (!renderedItems.size) return;
+
     let min = Infinity;
     let max = 0;
 
@@ -354,10 +356,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       if (longerBorder < min) min = longerBorder;
     });
 
+    // When `min` is equal to `max`, `scaleSprite` will draw all piles at
+    // `minRange + ((maxRange - minRange) / 2)`, which is not what we want sp
+    // we artificially subscract a small value from `min` to make pile being
+    // drawn at `maxRange`.
+    min -= min === max ? 0.1 : 0;
+
     const { itemSizeRange } = store.getState();
     let range;
 
-    const minRange = Math.min(layout.colWidth - 4, layout.rowHeight - 4);
+    const minRange = Math.min(layout.colWidth, layout.rowHeight);
 
     // if it's within [0, 1] assume it's relative
     if (

--- a/src/library.js
+++ b/src/library.js
@@ -585,8 +585,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           [i, j] = getCellPosition(id);
         }
 
-        // Make sure that the there is always one extra row
-        layout.numRows = Math.max(layout.numRows, j + EXTRA_ROWS);
+        layout.numRows = j + 1;
 
         const [x, y] = layout.ijToXy(
           i,

--- a/src/library.js
+++ b/src/library.js
@@ -286,7 +286,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   let layout;
 
   const updateScrollContainer = () => {
-    const finalHeight = Math.round(layout.rowHeight) * layout.rowNum;
+    const finalHeight = Math.round(layout.rowHeight) * layout.numRows;
     const canvasHeight = canvas.getBoundingClientRect().height;
     const extraHeight = Math.round(layout.rowHeight) * EXTRA_ROWS;
     scrollContainer.style.height = `${Math.max(
@@ -414,16 +414,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     const { orderer } = store.getState();
 
-    layout.rowNum = Math.ceil(renderedItems.size / layout.colNum);
+    layout.numRows = Math.ceil(renderedItems.size / layout.numColumns);
     pileInstances.forEach(pile => {
       const oldRowNum = Math.floor(pile.cY / oldLayout.rowHeight);
       const oldColumnNum = Math.floor(pile.cX / oldLayout.columnWidth);
 
-      const cellIndex = Math.round(oldRowNum * oldLayout.colNum + oldColumnNum);
-      const getCellPosition = orderer(layout.colNum);
+      const cellIndex = Math.round(
+        oldRowNum * oldLayout.numColumns + oldColumnNum
+      );
+      const getCellPosition = orderer(layout.numColumns);
       const [i, j] = getCellPosition(cellIndex);
-
-      if (pile.id === 4) console.log('pile #4', cellIndex, i, j);
 
       const [x, y] = layout.ijToXy(
         i,
@@ -477,7 +477,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     });
 
     renderedItems.forEach(item => {
-      const getCellPosition = orderer(layout.colNum);
+      const getCellPosition = orderer(layout.numColumns);
       const [i, j] = getCellPosition(item.id);
       item.originalPosition = layout.ijToXy(
         i,
@@ -581,12 +581,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         if (items[id].position) {
           [i, j] = items[id].position;
         } else {
-          const getCellPosition = orderer(layout.colNum);
+          const getCellPosition = orderer(layout.numColumns);
           [i, j] = getCellPosition(id);
         }
 
         // Make sure that the there is always one extra row
-        layout.rowNum = Math.max(layout.rowNum, j + 1);
+        layout.numRows = Math.max(layout.numRows, j + EXTRA_ROWS);
 
         const [x, y] = layout.ijToXy(
           i,
@@ -727,8 +727,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const updateGridMat = pileId => {
     const mat = ndarray(
-      new Uint16Array(new Array(layout.colNum * layout.rowNum).fill(0)),
-      [layout.rowNum, layout.olNum]
+      new Uint16Array(new Array(layout.numColumns * layout.numRows).fill(0)),
+      [layout.numRows, layout.olNum]
     );
 
     gridMat = mat;
@@ -850,7 +850,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     // doesn't find an available cell
     if (!depilePos) {
       depilePos = [resultMat.shape[0] + 1, Math.floor(filterRowNum / 2)];
-      layout.rowNum += filterRowNum;
+      layout.numRows += filterRowNum;
       updateScrollContainer();
     }
 
@@ -865,9 +865,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     const resultMat = ndarray(
       new Float32Array(
-        (layout.rowNum - filterRowNum + 1) * (layout.colNum - filterColNum + 1)
+        (layout.numRows - filterRowNum + 1) *
+          (layout.numColumns - filterColNum + 1)
       ),
-      [layout.rowNum - filterRowNum + 1, layout.olNum - filterColNum + 1]
+      [layout.numRows - filterRowNum + 1, layout.olNum - filterColNum + 1]
     );
 
     convolve(resultMat, gridMat, filter);
@@ -881,10 +882,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const distanceMat = ndarray(
       new Float32Array(
         new Array(
-          (layout.rowNum - rowNum + 1) * (layout.colNum - colNum + 1)
+          (layout.numRows - rowNum + 1) * (layout.numColumns - colNum + 1)
         ).fill(-1)
       ),
-      [layout.rowNum - rowNum + 1, layout.colNum - colNum + 1]
+      [layout.numRows - rowNum + 1, layout.numColumns - colNum + 1]
     );
 
     const depilePos = findDepilePos(distanceMat, resultMat, origin, rowNum);

--- a/src/store.js
+++ b/src/store.js
@@ -98,11 +98,11 @@ const [orderer, setOrderer] = setter('orderer', createOrderer().rowMajor);
 
 // Grid
 const [itemSize, setItemSize] = setter('itemSize');
-const [itemSizeRange, setItemSizeRange] = setter('itemSizeRange', [0.7, 0.9]);
+const [itemSizeRange, setItemSizeRange] = setter('itemSizeRange', [0.5, 1.0]);
 const [columns, setColumns] = setter('columns', 10);
 const [rowHeight, setRowHeight] = setter('rowHeight');
 const [cellAspectRatio, setCellAspectRatio] = setter('cellAspectRatio', 1);
-const [itemPadding, setItemPadding] = setter('itemPadding', 0);
+const [itemPadding, setItemPadding] = setter('itemPadding', 6);
 
 const [itemAlignment, setItemAlignment] = setter('itemAlignment', [
   'bottom',

--- a/src/utils.js
+++ b/src/utils.js
@@ -217,6 +217,50 @@ export const interpolateVector = (a, b) => p =>
   a.map((x, i) => interpolateNumber(x, b[i])(p));
 
 /**
+ * Debounce a function call
+ *
+ * @description
+ * Function calls are delayed by `wait` milliseconds and only one out of
+ * multiple function calls is executed.
+ *
+ * @method  debounce
+ * @author  Fritz Lekschas
+ * @date    2017-01-14
+ * @param   {Function}   func       Function to be debounced
+ * @param   {Number}     wait       Number of milliseconds to debounce the
+ *   function call.
+ * @param   {Boolean}    immediate  If `true` function is not debounced.
+ * @return  {Function}             Debounced function.
+ */
+export const debounce = (func, wait, immediate) => {
+  let timeout;
+
+  const debounced = (...args) => {
+    const later = () => {
+      timeout = null;
+      if (!immediate) {
+        func(...args);
+      }
+    };
+
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+
+    if (callNow) {
+      func(...args);
+    }
+  };
+
+  debounce.cancel = () => {
+    clearTimeout(timeout);
+    timeout = null;
+  };
+
+  return debounced;
+};
+
+/**
  * Throttle and debounce a function call
  *
  * Throttling a function call means that the function is called at most every


### PR DESCRIPTION
## Description

> What was changed in this pull request?

I refactored the grid as follows:
- `layout.cellWidth` is now called `layout.columnWidth`
- `layout.colWidth` is now called `layout.cellWidth`
- `layout.cellHeight` is now called `layout.rowHeight`
- `layout.rowHeight` is now called `layout.cellHeight`
- `layout.colNum` is now called `layout.numColumns`
- `layout.rowNum` is now called `layout.numRows`
- All properties but `layout.numRows` are read-only now

Simplified `resizeHandler()` and debounced it.

Changed the default value of `itemSizeRange` from `[0.7, 0.9]` to `[0.5, 1.0]` to make full use of the cell width.

Changed the default value of `itemPadding` from `0` to `6` to ensure some padding.

Slightly adjusted the examples to avoid overly big or small items.

> Why is it necessary?

Some variable names were a bit misleading. E.g., `colNum` could be interpreted as `column numbers` or `column number`. Since we use the column number elsewhere as a variable name I decided to go with `numColumns`.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [x] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
