### PR TITLE
Flekschas/rename properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   - `pileScale`
   - `pileBorderSize`
   - `itemOpacity`
+- Rename the following properties for clarity:
+  - `itemPadding` is now called `cellPadding`
+  - `pileCellAlign` is now called `pileCellAlignment`
+  - `itemAlignment` is now called `pileItemAlignment`
+  - `itemRotated` is now called `pileItemRotation`
 
 ## v0.4.2
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -164,22 +164,22 @@ The list of all understood properties is given below.
 | easing                    | function          | cubicInOut            | see [`notes`](#notes)                                                         | `true`     |
 | gridColor                 | string or int     | `0x787878`            |                                                                               | `false`    |
 | gridOpacity               | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| itemAlignment             | array or boolean  | `['bottom', 'right']` | array of strings, including `top`, `left`, `bottom`, `right`, or just `false` | `true`     |
 | itemOpacity               | float or function | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
-| itemRotated               | boolean           | `false`               | `true` or `false`                                                             | `true`     |
 | items                     | array             | `[]`                  | see [`data`](#data)                                                           | `false`    |
 | itemSize                  | int               |                       | number of pixels                                                              | `true`     |
 | itemSizeRange             | array             | `[0.7, 0.9]`          | array of two numbers between (0, 1)                                           | `true`     |
 | columns                   | int               | `10`                  | ignored when `itemSize` is defined                                            | `false`    |
 | rowHeight                 | int               |                       |                                                                               | `true`     |
 | cellAspectRatio           | float             |                       | ignored when `rowHeight` is defined                                           | `false`    |
-| itemPadding               | int               |                       |                                                                               | `true`     |
+| cellPadding               | int               |                       |                                                                               | `true`     |
 | lassoFillColor            | string or int     | `0xffffff`            |                                                                               | `false`    |
 | lassoFillOpacity          | float             | `0.15`                | must be in [`0`,`1`]                                                          | `false`    |
 | lassoStrokeColor          | string or int     | `0xffffff`            |                                                                               | `false`    |
 | lassoStrokeOpacity        | float             | `0.8`                 | must be in [`0`,`1`]                                                          | `false`    |
 | lassoStrokeSize           | int               | `1`                   | must be greater or equal than `1`                                             | `false`    |
 | orderer                   | function          | row-major             | see [`notes`](#notes)                                                         | `true`     |
+| pileBackgroundColor       | string or int     | `0x000000`            |                                                                               | `false`    |
+| pileBackgroundOpacity     | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
 | pileBorderColor           | string or int     | `0x808080`            |                                                                               | `false`    |
 | pileBorderOpacity         | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
 | pileBorderColorSelected   | string or int     | `0xeee462`            |                                                                               | `false`    |
@@ -187,10 +187,10 @@ The list of all understood properties is given below.
 | pileBorderColorActive     | string or int     | `0xffa5da`            |                                                                               | `false`    |
 | pileBorderOpacityActive   | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
 | pileBorderSize            | float or function | 0                     | see [`notes`](#notes)                                                         | `true`     |
-| pileBackgroundColor       | string or int     | `0x000000`            |                                                                               | `false`    |
-| pileBackgroundOpacity     | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| pileCellAlign             | string            | `topLeft`             | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
+| pileCellAlignment         | string            | `topLeft`             | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
 | pileContextMenuItems      | array             | `[]`                  | see _examples_ below                                                          | `true`     |
+| pileItemAlignment         | array or boolean  | `['bottom', 'right']` | array of strings, including `top`, `left`, `bottom`, `right`, or just `false` | `true`     |
+| pileItemRotation          | boolean           | `false`               | `true` or `false`                                                             | `true`     |
 | pileOpacity               | float or function | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
 | pileScale                 | float or function | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
 | previewAggregator         | function          |                       | see [`aggregators`](#aggregators)                                             | `true`     |
@@ -233,11 +233,11 @@ The list of all understood properties is given below.
   const rowMajor = cols => index => [index % cols, Math.floor(index / cols)];
   ```
 
-- The following properties to define the _grid_: `itemSize`, `itemPadding`, `columns`, `rowHeight`, and `cellAspectRatio`
+- The following properties to define the _grid_: `itemSize`, `cellPadding`, `columns`, `rowHeight`, and `cellAspectRatio`
 
   One has to at least provide `columns` or `itemSize` to define a grid. If `itemSize` is defined `columns` are ignored. Similarly, when `rowHeight` is defined `cellAspectRatio` is ignored.
 
-  When `itemSize` is defined, `itemSize` and `itemPadding` add up together to define the cell width. When `itemSize` is undefined, `itemSize` is defined by the derived cell width (given `columns`) minues `itemPadding`!
+  When `itemSize` is defined, `itemSize` and `cellPadding` add up together to define the cell width. When `itemSize` is undefined, `itemSize` is defined by the derived cell width (given `columns`) minues `cellPadding`!
 
 - `easing` is the easing function for animation, the default function is `cubicInOut` which looks like this:
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -190,7 +190,7 @@ createPiles(exampleEl.value).then(pilingLib => {
           nullifiable: true
         },
         {
-          name: 'pileCellAlign',
+          name: 'pileCellAlignment',
           dtype: 'string',
           values: ['topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'center']
         }

--- a/examples/index.js
+++ b/examples/index.js
@@ -163,7 +163,7 @@ createPiles(exampleEl.value).then(pilingLib => {
           nullifiable: true
         },
         {
-          name: 'itemPadding',
+          name: 'cellPadding',
           dtype: 'int',
           min: 0,
           max: 64,

--- a/examples/lines.js
+++ b/examples/lines.js
@@ -27,8 +27,8 @@ const createSvgLinesPiles = element => {
   const piling = createPilingJs(element, {
     renderer: svgRenderer,
     items: data,
-    itemAlignment: ['top', 'bottom', 'left', 'right'],
     itemOpacity: (item, i, pile) => 1 / pile.items.length / 2 / 3 + 1 / 3,
+    pileItemAlignment: ['top', 'bottom', 'left', 'right'],
     pileBackgroundColor: 'rgba(255, 255, 255, 0.66)',
     backgroundColor: '#ffffff',
     lassoFillColor: '#000000',

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -13,7 +13,7 @@ const createPhotoPiles = async element => {
   piling.set('renderer', imageRenderer);
   piling.set('items', data);
 
-  piling.set('pileCellAlign', 'center');
+  piling.set('pileCellAlignment', 'center');
 
   piling.set('pileBorderSize', pile => pile.items.length - 1);
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -9,7 +9,7 @@ import { l1Dist, l2Norm, normalizeVector } from './utils';
  * @param {number} columns - The number of column
  * @param {number} rowHeight - The height of row
  * @param {number} cellAspectRatio - The ratio of cell height and width
- * @param {number} itemPadding - The padding between items
+ * @param {number} cellPadding - The padding between items
  */
 const createGrid = (
   canvas,
@@ -19,7 +19,7 @@ const createGrid = (
     rowHeight = null,
     cellAspectRatio = 1,
     pileCellAlign = 'topLeft',
-    itemPadding = 0
+    cellPadding = 0
   } = {}
 ) => {
   const { width } = canvas.getBoundingClientRect();
@@ -27,11 +27,11 @@ const createGrid = (
   let numColumns = columns;
   let numRows;
   let columnWidth = width / columns;
-  let cellWidth = columnWidth - itemPadding * 2;
+  let cellWidth = columnWidth - cellPadding * 2;
   let cellHeight = null;
 
   if (+itemSize) {
-    columnWidth = itemSize + itemPadding * 2;
+    columnWidth = itemSize + cellPadding * 2;
     numColumns = Math.floor(width / columnWidth);
     cellWidth = itemSize;
   }
@@ -44,7 +44,7 @@ const createGrid = (
     cellAspectRatio = columnWidth / rowHeight;
   }
 
-  cellHeight = rowHeight - itemPadding * 2;
+  cellHeight = rowHeight - cellPadding * 2;
 
   const columnWidthHalf = columnWidth / 2;
   const rowHeightHalf = rowHeight / 2;
@@ -79,8 +79,8 @@ const createGrid = (
     }
 
     const topLeft = [
-      i * columnWidth + itemPadding,
-      j * rowHeight + itemPadding
+      i * columnWidth + cellPadding,
+      j * rowHeight + cellPadding
     ];
 
     switch (pileCellAlign) {
@@ -292,8 +292,8 @@ const createGrid = (
     get cellAspectRatio() {
       return cellAspectRatio;
     },
-    get itemPadding() {
-      return itemPadding;
+    get cellPadding() {
+      return cellPadding;
     },
     // Methods
     align,

--- a/src/grid.js
+++ b/src/grid.js
@@ -18,7 +18,7 @@ const createGrid = (
     columns = 10,
     rowHeight = null,
     cellAspectRatio = 1,
-    pileCellAlign = 'topLeft',
+    pileCellAlignment = 'topLeft',
     cellPadding = 0
   } = {}
 ) => {
@@ -83,7 +83,7 @@ const createGrid = (
       j * rowHeight + cellPadding
     ];
 
-    switch (pileCellAlign) {
+    switch (pileCellAlignment) {
       case 'topRight':
         return [topLeft[0] + cellWidth - pileWidth, topLeft[1]];
 

--- a/src/library.js
+++ b/src/library.js
@@ -101,7 +101,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     rowHeight: true,
     cellAspectRatio: true,
     cellPadding: true,
-    itemAlignment: true,
+    pileItemAlignment: true,
     itemRotated: true,
     gridColor: {
       set: value => {
@@ -491,10 +491,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           store.getState().previewSpacing;
         pile.cover.height = coverRatio * pile.cover.width;
 
-        const { itemAlignment, itemRotated } = store.getState();
+        const { pileItemAlignment, itemRotated } = store.getState();
 
         pile.positionItems(
-          itemAlignment,
+          pileItemAlignment,
           itemRotated,
           animator,
           store.getState().previewSpacing
@@ -666,12 +666,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const positionItems = pileId => {
-    const { itemAlignment, itemRotated } = store.getState();
+    const { pileItemAlignment, itemRotated } = store.getState();
 
     pileInstances
       .get(pileId)
       .positionItems(
-        itemAlignment,
+        pileItemAlignment,
         itemRotated,
         animator,
         store.getState().previewSpacing
@@ -1480,7 +1480,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       stateUpdates.add('layout');
     }
 
-    if (state.itemAlignment !== newState.itemAlignment) {
+    if (state.pileItemAlignment !== newState.pileItemAlignment) {
       stateUpdates.add('layout');
     }
 

--- a/src/library.js
+++ b/src/library.js
@@ -102,7 +102,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     cellAspectRatio: true,
     cellPadding: true,
     pileItemAlignment: true,
-    itemRotated: true,
+    pileItemRotation: true,
     gridColor: {
       set: value => {
         const [color, opacity] = colorToDecAlpha(value, null);
@@ -491,11 +491,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           store.getState().previewSpacing;
         pile.cover.height = coverRatio * pile.cover.width;
 
-        const { pileItemAlignment, itemRotated } = store.getState();
+        const { pileItemAlignment, pileItemRotation } = store.getState();
 
         pile.positionItems(
           pileItemAlignment,
-          itemRotated,
+          pileItemRotation,
           animator,
           store.getState().previewSpacing
         );
@@ -666,13 +666,13 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const positionItems = pileId => {
-    const { pileItemAlignment, itemRotated } = store.getState();
+    const { pileItemAlignment, pileItemRotation } = store.getState();
 
     pileInstances
       .get(pileId)
       .positionItems(
         pileItemAlignment,
-        itemRotated,
+        pileItemRotation,
         animator,
         store.getState().previewSpacing
       );
@@ -1484,7 +1484,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       stateUpdates.add('layout');
     }
 
-    if (state.itemRotated !== newState.itemRotated) {
+    if (state.pileItemRotation !== newState.pileItemRotation) {
       stateUpdates.add('layout');
     }
 

--- a/src/library.js
+++ b/src/library.js
@@ -100,7 +100,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     columns: true,
     rowHeight: true,
     cellAspectRatio: true,
-    itemPadding: true,
+    cellPadding: true,
     itemAlignment: true,
     itemRotated: true,
     gridColor: {
@@ -350,7 +350,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       rowHeight,
       cellAspectRatio,
       pileCellAlign,
-      itemPadding
+      cellPadding
     } = store.getState();
 
     layout = createGrid(canvas, {
@@ -359,7 +359,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       rowHeight,
       cellAspectRatio,
       pileCellAlign,
-      itemPadding
+      cellPadding
     });
 
     updateScrollContainer();
@@ -374,7 +374,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       rowHeight,
       cellAspectRatio,
       pileCellAlign,
-      itemPadding
+      cellPadding
     } = store.getState();
 
     layout = createGrid(canvas, {
@@ -383,7 +383,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       rowHeight,
       cellAspectRatio,
       pileCellAlign,
-      itemPadding
+      cellPadding
     });
 
     // eslint-disable-next-line no-use-before-define
@@ -1473,7 +1473,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       state.columns !== newState.columns ||
       state.rowHeight !== newState.rowHeight ||
       state.cellAspectRatio !== newState.cellAspectRatio ||
-      state.itemPadding !== newState.itemPadding ||
+      state.cellPadding !== newState.cellPadding ||
       state.pileCellAlign !== newState.pileCellAlign
     ) {
       stateUpdates.add('grid');

--- a/src/library.js
+++ b/src/library.js
@@ -176,7 +176,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     pileBackgroundOpacity: true,
-    pileCellAlign: true,
+    pileCellAlignment: true,
     pileContextMenuItems: true,
     pileOpacity: true,
     pileScale: true,
@@ -349,7 +349,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       columns,
       rowHeight,
       cellAspectRatio,
-      pileCellAlign,
+      pileCellAlignment,
       cellPadding
     } = store.getState();
 
@@ -358,7 +358,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       columns,
       rowHeight,
       cellAspectRatio,
-      pileCellAlign,
+      pileCellAlignment,
       cellPadding
     });
 
@@ -373,7 +373,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       columns,
       rowHeight,
       cellAspectRatio,
-      pileCellAlign,
+      pileCellAlignment,
       cellPadding
     } = store.getState();
 
@@ -382,7 +382,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       columns,
       rowHeight,
       cellAspectRatio,
-      pileCellAlign,
+      pileCellAlignment,
       cellPadding
     });
 
@@ -1474,7 +1474,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       state.rowHeight !== newState.rowHeight ||
       state.cellAspectRatio !== newState.cellAspectRatio ||
       state.cellPadding !== newState.cellPadding ||
-      state.pileCellAlign !== newState.pileCellAlign
+      state.pileCellAlignment !== newState.pileCellAlignment
     ) {
       stateUpdates.add('grid');
       stateUpdates.add('layout');

--- a/src/pile.js
+++ b/src/pile.js
@@ -397,7 +397,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     animator.add(tweener);
   };
 
-  const positionItems = (itemAlignment, itemRotated, animator, spacing) => {
+  const positionItems = (itemAlignment, itemRotation, animator, spacing) => {
     isPositioning = true;
     if (hasCover) {
       // matrix
@@ -525,7 +525,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
           num === newItems.size
         );
 
-        if (itemRotated) {
+        if (itemRotation) {
           item.sprite.angle += getRandomArbitrary(-10, 10);
         }
       });

--- a/src/store.js
+++ b/src/store.js
@@ -115,7 +115,10 @@ const [pileItemAlignment, setPileItemAlignment] = setter('pileItemAlignment', [
   'right'
 ]);
 
-const [itemRotated, setItemRotated] = setter('itemRotated', false);
+const [pileItemRotation, setPileItemRotation] = setter(
+  'pileItemRotation',
+  false
+);
 
 const [focusedPiles, setFocusedPiles] = setter('focusedPiles', []);
 
@@ -356,7 +359,7 @@ const createStore = () => {
     pileItemAlignment,
     itemOpacity,
     itemRenderer,
-    itemRotated,
+    pileItemRotation,
     items,
     lassoFillColor,
     lassoFillOpacity,
@@ -446,7 +449,7 @@ export const createAction = {
   setCellAspectRatio,
   setCellPadding,
   setPileItemAlignment,
-  setItemRotated,
+  setPileItemRotation,
   setFocusedPiles,
   setScaledPile,
   setShowGrid,

--- a/src/store.js
+++ b/src/store.js
@@ -110,7 +110,7 @@ const [rowHeight, setRowHeight] = setter('rowHeight');
 const [cellAspectRatio, setCellAspectRatio] = setter('cellAspectRatio', 1);
 const [cellPadding, setCellPadding] = setter('cellPadding', 12);
 
-const [itemAlignment, setItemAlignment] = setter('itemAlignment', [
+const [pileItemAlignment, setPileItemAlignment] = setter('pileItemAlignment', [
   'bottom',
   'right'
 ]);
@@ -353,7 +353,7 @@ const createStore = () => {
     gridColor,
     gridOpacity,
     cellPadding,
-    itemAlignment,
+    pileItemAlignment,
     itemOpacity,
     itemRenderer,
     itemRotated,
@@ -445,7 +445,7 @@ export const createAction = {
   setRowHeight,
   setCellAspectRatio,
   setCellPadding,
-  setItemAlignment,
+  setPileItemAlignment,
   setItemRotated,
   setFocusedPiles,
   setScaledPile,

--- a/src/store.js
+++ b/src/store.js
@@ -108,7 +108,7 @@ const [itemSizeRange, setItemSizeRange] = setter('itemSizeRange', [0.5, 1.0]);
 const [columns, setColumns] = setter('columns', 10);
 const [rowHeight, setRowHeight] = setter('rowHeight');
 const [cellAspectRatio, setCellAspectRatio] = setter('cellAspectRatio', 1);
-const [itemPadding, setItemPadding] = setter('itemPadding', 12);
+const [cellPadding, setCellPadding] = setter('cellPadding', 12);
 
 const [itemAlignment, setItemAlignment] = setter('itemAlignment', [
   'bottom',
@@ -349,7 +349,7 @@ const createStore = () => {
     cellAspectRatio,
     gridColor,
     gridOpacity,
-    itemPadding,
+    cellPadding,
     itemAlignment,
     itemOpacity,
     itemRenderer,
@@ -441,7 +441,7 @@ export const createAction = {
   setColumns,
   setRowHeight,
   setCellAspectRatio,
-  setItemPadding,
+  setCellPadding,
   setItemAlignment,
   setItemRotated,
   setFocusedPiles,

--- a/src/store.js
+++ b/src/store.js
@@ -199,7 +199,10 @@ const [pileBackgroundOpacity, setPileBackgroundOpacity] = setter(
 );
 
 // 'topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'center'
-const [pileCellAlign, setPileCellAlign] = setter('pileCellAlign', 'topLeft');
+const [pileCellAlignment, setPileCellAlignment] = setter(
+  'pileCellAlignment',
+  'topLeft'
+);
 
 const [pileContextMenuItems, setPileContextMenuItems] = setter(
   'pileContextMenuItems',
@@ -370,7 +373,7 @@ const createStore = () => {
     pileBorderSize,
     pileBackgroundColor,
     pileBackgroundOpacity,
-    pileCellAlign,
+    pileCellAlignment,
     pileContextMenuItems,
     pileOpacity,
     piles,
@@ -468,5 +471,5 @@ export const createAction = {
   setPileContextMenuItems,
   setPileOpacity,
   setPileScale,
-  setPileCellAlign
+  setPileCellAlignment
 };


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Renamed the following properties for clarity:
  - `itemPadding` is now called `cellPadding`
  - `pileCellAlign` is now called `pileCellAlignment`
  - `itemAlignment` is now called `pileItemAlignment`
  - `itemRotated` is now called `pileItemRotation`

> Why is it necessary?

Fixes #74 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
