### PR TITLE
Animate item rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Next
 
+- Add `randomOffsetRange` and `randomRotationRange` properties.
+- Animate item rotation.
+
 ## v0.5.0
 
 - Add the following properties for dynamic styling. Each property accepts a float value or a callback function. See [`DOCS.md`](DOCS.md#pilingsetproperty-value) for details.

--- a/DOCS.md
+++ b/DOCS.md
@@ -196,6 +196,8 @@ The list of all understood properties is given below.
 | previewAggregator         | function          |                       | see [`aggregators`](#aggregators)                                             | `true`     |
 | previewRenderer           | function          |                       | see [`renderers`](#renderers)                                                 | `true`     |
 | previewSpacing            | number            | `2`                   | the spacing between 1D previews                                               | `true`     |
+| randomOffsetRange         | array             | `[-30, 30]`          | array of two numbers                                                           | `true`     |
+| randomRotationRange       | array             | `[-10, 10]`          | array of two numbers                                                           | `true`     |
 | renderer                  | function          |                       | see [`renderers`](#renderers)                                                 | `false`    |
 | scaledPile                | array             | `[]`                  | the id of current scaled pile                                                 | `true`     |
 | showGrid                  | boolean           | `false`               |                                                                               | `false`    |

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -17,6 +17,9 @@ const createPhotoPiles = async element => {
 
   piling.set('pileBorderSize', pile => pile.items.length - 1);
 
+  piling.set('pileItemAlignment', false);
+  piling.set('pileItemRotation', true);
+
   return piling;
 };
 

--- a/src/item.js
+++ b/src/item.js
@@ -21,7 +21,6 @@ const createItem = (id, texture, preview, pubSub) => {
     clonedSprite.y = sprite.y;
     clonedSprite.width = sprite.width;
     clonedSprite.height = sprite.height;
-    clonedSprite.angle = sprite.angle;
 
     return clonedSprite;
   };

--- a/src/library.js
+++ b/src/library.js
@@ -193,6 +193,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     previewBackgroundOpacity: true,
+    randomOffsetRange: true,
+    randomRotationRange: true,
     renderer: {
       get: 'itemRenderer',
       set: value => [createAction.setItemRenderer(value)]
@@ -966,19 +968,23 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const movingPiles = [];
     items.forEach((itemId, index) => {
       const pile = pileInstances.get(itemId);
+      const item = renderedItems.get(itemId);
       const tweener = createTweener({
         duration: 250,
         delay: 0,
         interpolator: interpolateVector,
-        endValue:
-          itemPositions.length > 0
+        endValue: [
+          ...(itemPositions.length > 0
             ? itemPositions[index]
-            : renderedItems.get(itemId).originalPosition,
+            : item.originalPosition),
+          0
+        ],
         getter: () => {
-          return [pile.x, pile.y];
+          return [pile.x, pile.y, item.sprite.angle];
         },
-        setter: xy => {
-          pile.moveTo(...xy);
+        setter: newValue => {
+          pile.moveTo(newValue[0], newValue[1]);
+          item.sprite.angle = newValue[2];
         },
         onDone: finalValue => {
           movingPiles.push({

--- a/src/pile.js
+++ b/src/pile.js
@@ -364,7 +364,14 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
 
   // Map to store calls for after the pile position animation
   const postPilePositionAnimation = new Map();
-  const animatePositionItems = (itemSprite, x, y, animator, isLastOne) => {
+  const animatePositionItems = (
+    itemSprite,
+    x,
+    y,
+    angle,
+    animator,
+    isLastOne
+  ) => {
     const targetScale = itemSprite.tmpTargetScale || itemSprite.scale.x;
     itemSprite.tmpTargetScale = undefined;
     delete itemSprite.tmpTargetScale;
@@ -372,15 +379,21 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     const tweener = createTweener({
       duration: 250,
       interpolator: interpolateVector,
-      endValue: [x, y, targetScale],
+      endValue: [x, y, targetScale, angle],
       getter: () => {
-        return [itemSprite.x, itemSprite.y, itemSprite.scale.x];
+        return [
+          itemSprite.x,
+          itemSprite.y,
+          itemSprite.scale.x,
+          itemSprite.angle
+        ];
       },
       setter: newValue => {
         itemSprite.x = newValue[0];
         itemSprite.y = newValue[1];
         itemSprite.scale.x = newValue[2];
         itemSprite.scale.y = itemSprite.scale.x;
+        itemSprite.angle = newValue[3];
       },
       onDone: () => {
         itemSprite.tmpTargetScale = undefined;
@@ -399,6 +412,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
 
   const positionItems = (itemAlignment, itemRotation, animator, spacing) => {
     isPositioning = true;
+    let angle = 0;
     if (hasCover) {
       // matrix
       itemContainer.children.forEach((item, index) => {
@@ -410,11 +424,12 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
           item,
           2 - spacing / 2,
           -padding,
+          angle,
           animator,
           index === itemContainer.children.length - 2
         );
       });
-    } else if (itemAlignment) {
+    } else if (itemAlignment || items.length === 1) {
       // image
       newItems.forEach(item => {
         const sprite = item.sprite;
@@ -477,11 +492,13 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
           item,
           horizontalPadding + 2,
           verticalPadding + 2,
+          angle,
           animator,
           index === itemContainer.children.length - 1
         );
       });
     } else {
+      const { randomOffsetRange, randomRotationRange } = store.getState();
       let num = 0;
       newItems.forEach(item => {
         num++;
@@ -501,8 +518,8 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
           delete item.tmpRelScale;
         }
 
-        let offsetX = getRandomArbitrary(-30, 30);
-        let offsetY = getRandomArbitrary(-30, 30);
+        let offsetX = getRandomArbitrary(...randomOffsetRange);
+        let offsetY = getRandomArbitrary(...randomOffsetRange);
 
         if (!Number.isNaN(+item.tmpAbsX) && !Number.isNaN(+item.tmpAbsY)) {
           offsetX += item.x;
@@ -517,17 +534,18 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
           delete item.tmpAbsY;
         }
 
+        if (itemRotation) {
+          angle = getRandomArbitrary(...randomRotationRange);
+        }
+
         animatePositionItems(
           sprite,
           offsetX,
           offsetY,
+          angle,
           animator,
           num === newItems.size
         );
-
-        if (itemRotation) {
-          item.sprite.angle += getRandomArbitrary(-10, 10);
-        }
       });
     }
     newItems.clear();

--- a/src/store.js
+++ b/src/store.js
@@ -216,6 +216,16 @@ const [pileOpacity, setPileOpacity] = setter('pileOpacity', 1.0);
 
 const [pileScale, setPileScale] = setter('pileScale', 1.0);
 
+const [randomOffsetRange, setRandomOffsetRange] = setter('randomOffsetRange', [
+  -30,
+  30
+]);
+
+const [
+  randomRotationRange,
+  setRandomRotationRange
+] = setter('randomRotationRange', [-10, 10]);
+
 // reducer
 const piles = (previousState = [], action) => {
   switch (action.type) {
@@ -386,6 +396,8 @@ const createStore = () => {
     previewBackgroundOpacity,
     previewRenderer,
     previewSpacing,
+    randomOffsetRange,
+    randomRotationRange,
     scaledPile,
     showGrid,
     tempDepileDirection,
@@ -474,5 +486,7 @@ export const createAction = {
   setPileContextMenuItems,
   setPileOpacity,
   setPileScale,
-  setPileCellAlignment
+  setPileCellAlignment,
+  setRandomOffsetRange,
+  setRandomRotationRange
 };


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add `randomOffsetRange` and `randomRotationRange` to Redux store.

Animate item rotation when piling up and depiling.

> Why is it necessary?

Fixes #69 and #75.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
