### PR TITLE
Refactor scale pile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Next
 
+- Fix pile scaling
+
 ## v0.5.0
 
 - Add the following properties for dynamic styling. Each property accepts a float value or a callback function. See [`DOCS.md`](DOCS.md#pilingsetproperty-value) for details.

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -50,7 +50,7 @@ const createMatrixPiles = async element => {
     previewAggregator: matrixPreviewAggregator,
     items: data,
     itemSize: 64,
-    pileCellAlign: 'center',
+    pileCellAlignment: 'center',
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
   });
 

--- a/src/library.js
+++ b/src/library.js
@@ -1741,7 +1741,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const scaleBtnClick = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
-    if (pile.graphics.scale.x > 1.1) {
+    if (pile.graphics.scale.x > 1) {
       store.dispatch(createAction.setScaledPile([]));
     } else {
       store.dispatch(createAction.setScaledPile([pileId]));
@@ -1827,7 +1827,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           results.forEach(result => {
             const pile = pileInstances.get(result.pileId);
             if (pile.graphics.isHover) {
-              if (pile.graphics.scale.x > 1.1) {
+              if (pile.graphics.scale.x > 1) {
                 store.dispatch(createAction.setScaledPile([]));
               } else {
                 store.dispatch(createAction.setScaledPile([result.pileId]));
@@ -1903,8 +1903,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       if (event.altKey) {
         event.preventDefault();
         store.dispatch(createAction.setScaledPile([result[0].pileId]));
-        const normalizedDeltaY = normalizeWheel(event).pixelY;
-        scalePile(result[0].pileId, normalizedDeltaY);
+        scalePile(result[0].pileId, normalizeWheel(event).pixelY);
       }
     }
   };

--- a/src/library.js
+++ b/src/library.js
@@ -1547,10 +1547,14 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       if (state.scaledPile.length !== 0) {
         if (pileInstances.has(state.scaledPile[0])) {
           const pile = pileInstances.get(state.scaledPile[0]).graphics;
-          pile.scale(1);
-          updateBoundingBox(state.scaledPile[0]);
           activePile.removeChildren();
           normalPiles.addChild(pile);
+        }
+      }
+      if (newState.scaledPile.length !== 0) {
+        if (pileInstances.has(newState.scaledPile[0])) {
+          const pile = pileInstances.get(newState.scaledPile[0]).graphics;
+          activePile.addChild(pile);
         }
       }
       renderRaf();
@@ -1737,6 +1741,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const scaleBtnClick = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
+    if (pile.graphics.scale.x > 1.1) {
+      store.dispatch(createAction.setScaledPile([]));
+    } else {
+      store.dispatch(createAction.setScaledPile([pileId]));
+    }
     pile.scaleToggle();
 
     hideContextMenu(contextMenuElement);
@@ -1817,7 +1826,14 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         } else if (event.altKey) {
           results.forEach(result => {
             const pile = pileInstances.get(result.pileId);
-            if (pile.graphics.isHover) pile.animateScale();
+            if (pile.graphics.isHover) {
+              if (pile.graphics.scale.x > 1.1) {
+                store.dispatch(createAction.setScaledPile([]));
+              } else {
+                store.dispatch(createAction.setScaledPile([result.pileId]));
+              }
+              pile.scaleToggle();
+            }
           });
         } else {
           results.forEach(result => {
@@ -1889,8 +1905,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         store.dispatch(createAction.setScaledPile([result[0].pileId]));
         const normalizedDeltaY = normalizeWheel(event).pixelY;
         scalePile(result[0].pileId, normalizedDeltaY);
-        const graphics = pileInstances.get(result[0].pileId).graphics;
-        activePile.addChild(graphics);
       }
     }
   };

--- a/src/library.js
+++ b/src/library.js
@@ -1543,8 +1543,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       renderRaf();
     }
 
-    if (state.scaledPile !== newState.scaledPile) {
-      state.scaledPile
+    if (state.scaledPiles !== newState.scaledPiles) {
+      state.scaledPiles
         .map(scaledPile => pileInstances.get(scaledPile))
         .filter(scaledPileInstance => scaledPileInstance)
         .forEach(scaledPileInstance => {
@@ -1554,7 +1554,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           normalPiles.addChild(scaledPileInstance.graphics);
         });
 
-      newState.scaledPile
+      newState.scaledPiles
         .map(scaledPile => pileInstances.get(scaledPile))
         .filter(scaledPileInstance => scaledPileInstance)
         .forEach(scaledPileInstance => {
@@ -1746,9 +1746,9 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const scaleBtnClick = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
     if (pile.scale() > 1) {
-      store.dispatch(createAction.setScaledPile([]));
+      store.dispatch(createAction.setScaledPiles([]));
     } else {
-      store.dispatch(createAction.setScaledPile([pileId]));
+      store.dispatch(createAction.setScaledPiles([pileId]));
     }
     pile.scaleToggle();
 
@@ -1832,9 +1832,9 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             const pile = pileInstances.get(result.pileId);
             if (pile.graphics.isHover) {
               if (pile.scale() > 1) {
-                store.dispatch(createAction.setScaledPile([]));
+                store.dispatch(createAction.setScaledPiles([]));
               } else {
-                store.dispatch(createAction.setScaledPile([result.pileId]));
+                store.dispatch(createAction.setScaledPiles([result.pileId]));
               }
               pile.scaleToggle();
             }
@@ -1849,7 +1849,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         }
       } else {
         store.dispatch(createAction.setFocusedPiles([]));
-        store.dispatch(createAction.setScaledPile([]));
+        store.dispatch(createAction.setScaledPiles([]));
       }
     }
   };
@@ -1906,7 +1906,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     if (result.length !== 0) {
       if (event.altKey) {
         event.preventDefault();
-        store.dispatch(createAction.setScaledPile([result[0].pileId]));
+        store.dispatch(createAction.setScaledPiles([result[0].pileId]));
         scalePile(result[0].pileId, normalizeWheel(event).pixelY);
       }
     }

--- a/src/library.js
+++ b/src/library.js
@@ -1544,22 +1544,23 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     }
 
     if (state.scaledPile !== newState.scaledPile) {
-      if (state.scaledPile.length !== 0) {
-        const prevScaledPile = pileInstances.get(state.scaledPile[0]);
-        if (prevScaledPile) {
-          prevScaledPile.scale(1);
-          updateBoundingBox(prevScaledPile.id);
+      state.scaledPile
+        .map(scaledPile => pileInstances.get(scaledPile))
+        .filter(scaledPileInstance => scaledPileInstance)
+        .forEach(scaledPileInstance => {
+          scaledPileInstance.scale(1);
+          updateBoundingBox(scaledPileInstance.id);
           activePile.removeChildren();
-          normalPiles.addChild(prevScaledPile.graphics);
-        }
-      }
-      if (newState.scaledPile.length !== 0) {
-        if (pileInstances.has(newState.scaledPile[0])) {
-          activePile.addChild(
-            pileInstances.get(newState.scaledPile[0]).graphics
-          );
-        }
-      }
+          normalPiles.addChild(scaledPileInstance.graphics);
+        });
+
+      newState.scaledPile
+        .map(scaledPile => pileInstances.get(scaledPile))
+        .filter(scaledPileInstance => scaledPileInstance)
+        .forEach(scaledPileInstance => {
+          activePile.addChild(scaledPileInstance.graphics);
+        });
+
       renderRaf();
     }
 

--- a/src/library.js
+++ b/src/library.js
@@ -1545,16 +1545,19 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     if (state.scaledPile !== newState.scaledPile) {
       if (state.scaledPile.length !== 0) {
-        if (pileInstances.has(state.scaledPile[0])) {
-          const pile = pileInstances.get(state.scaledPile[0]).graphics;
+        const prevScaledPile = pileInstances.get(state.scaledPile[0]);
+        if (prevScaledPile) {
+          prevScaledPile.scale(1);
+          updateBoundingBox(prevScaledPile.id);
           activePile.removeChildren();
-          normalPiles.addChild(pile);
+          normalPiles.addChild(prevScaledPile.graphics);
         }
       }
       if (newState.scaledPile.length !== 0) {
         if (pileInstances.has(newState.scaledPile[0])) {
-          const pile = pileInstances.get(newState.scaledPile[0]).graphics;
-          activePile.addChild(pile);
+          activePile.addChild(
+            pileInstances.get(newState.scaledPile[0]).graphics
+          );
         }
       }
       renderRaf();
@@ -1741,7 +1744,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const scaleBtnClick = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
-    if (pile.graphics.scale.x > 1) {
+    if (pile.scale() > 1) {
       store.dispatch(createAction.setScaledPile([]));
     } else {
       store.dispatch(createAction.setScaledPile([pileId]));
@@ -1827,7 +1830,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           results.forEach(result => {
             const pile = pileInstances.get(result.pileId);
             if (pile.graphics.isHover) {
-              if (pile.graphics.scale.x > 1) {
+              if (pile.scale() > 1) {
                 store.dispatch(createAction.setScaledPile([]));
               } else {
                 store.dispatch(createAction.setScaledPile([result.pileId]));
@@ -2027,7 +2030,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           tempDepileBtn.innerHTML = 'close temp depile';
         }
 
-        if (pile.graphics.scale.x > 1.1) {
+        if (pile.scale() > 1) {
           scaleBtn.innerHTML = 'scale down';
         }
 

--- a/src/pile.js
+++ b/src/pile.js
@@ -587,7 +587,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
   };
 
   const scaleToggle = noAnimate => {
-    scale(graphics.scale.x > 1.1 ? 1 : MAX_SCALE, noAnimate);
+    scale(getScale() > 1 ? 1 : MAX_SCALE, noAnimate);
   };
 
   const moveTo = (x, y) => {

--- a/src/pile.js
+++ b/src/pile.js
@@ -586,10 +586,8 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     return oldScale !== newScale;
   };
 
-  let scaledUp = false;
   const scaleToggle = noAnimate => {
-    scale(scaledUp ? 1 : MAX_SCALE, noAnimate);
-    scaledUp = !scaledUp;
+    scale(graphics.scale.x > 1.1 ? 1 : MAX_SCALE, noAnimate);
   };
 
   const moveTo = (x, y) => {

--- a/src/store.js
+++ b/src/store.js
@@ -122,7 +122,7 @@ const [pileItemRotation, setPileItemRotation] = setter(
 
 const [focusedPiles, setFocusedPiles] = setter('focusedPiles', []);
 
-const [scaledPile, setScaledPile] = setter('scaledPile', []);
+const [scaledPiles, setScaledPiles] = setter('scaledPiles', []);
 
 // 'originalPos' and 'closestPos'
 const [depileMethod, setDepileMethod] = setter('depileMethod', 'originalPos');
@@ -386,7 +386,7 @@ const createStore = () => {
     previewBackgroundOpacity,
     previewRenderer,
     previewSpacing,
-    scaledPile,
+    scaledPiles,
     showGrid,
     tempDepileDirection,
     tempDepileOneDNum,
@@ -451,7 +451,7 @@ export const createAction = {
   setPileItemAlignment,
   setPileItemRotation,
   setFocusedPiles,
-  setScaledPile,
+  setScaledPiles,
   setShowGrid,
   setDepileMethod,
   setDepiledPile,

--- a/src/tweener.js
+++ b/src/tweener.js
@@ -36,12 +36,18 @@ const createTweener = ({
     setTimeout(startAnimation, delay);
   };
 
+  /**
+   * Set the value to the current progress given the elapsed time
+   * @return  {bool}  If `true` the animation is over
+   */
   const update = () => {
     if (!startValue) return false;
 
     dt = performance.now() - startTime;
 
     if (dt >= duration) {
+      // Ensure that the endValue is set
+      setter(endValue);
       if (onDone !== null) onDone(getter());
       return true;
     }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add the scaled-up pile to `activePile` to bring it to front.

Refactor `pile.scaleToggle()`. Whether the pile is being scaled up or down is determined by the pile's current scale now.

> Why is it necessary?

Fixes #72 and #73.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
