### PR TITLE
Restructure pile scene graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next
 
 - Add `randomOffsetRange` and `randomRotationRange` properties
+- Change pile border to be scale invariant
 - Animate item rotation
 - Fix pile scaling
 - Fix grid drawing to update dynamically upon changes to the grid

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -2,7 +2,6 @@
 
 **Note, if you are trying to find out how to use pile.js please go to the [main docs](DOCS.md). This file only contains information for developing pile.js!**
 
-
 # Depile
 
 The pseudocode for finding the closest available cell for de-piling.
@@ -34,7 +33,6 @@ while(!depilePos)
 return depilePos
 ```
 
-
 # PIXI.js Screengraph
 
 The `stage` is the root PIXI container that we render everything on.
@@ -44,18 +42,18 @@ The `stage` is the root PIXI container that we render everything on.
     - lasso graphics
   - active pile container
   - normal piles container
-    - pile graphics
-      - hover item container
-      - item container
-      - border container
+    - pile root graphics
+      - content graphics
+        - hover item container
+        - item container
+      - border graphics
   - lasso bg container
     - lasso fill graphics
   - grid graphics
 
-
 # Pile API
 
-Each visual [item](#item-api) is part of a pile. The pile class is the primary interface to manage and interact with the items. You never create pile instances yourself but 
+Each visual [item](#item-api) is part of a pile. The pile class is the primary interface to manage and interact with the items. You never create pile instances yourself but
 
 ## Pile properties
 
@@ -152,7 +150,6 @@ Destroy the pile instance.
 #### `pile.moveTo(x, y)`
 
 Move the pile graphics to position `[x, y]`.
-
 
 # Item API
 

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -50,8 +50,8 @@ const createMatrixPiles = async element => {
     previewAggregator: matrixPreviewAggregator,
     items: data,
     itemSize: 64,
-    pileCellAlign: 'center',
-    pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
+    pileCellAlignment: 'center'
+    // pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
   });
 
   return pilingJs;

--- a/src/library.js
+++ b/src/library.js
@@ -1640,7 +1640,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           pile.items.forEach(item => {
             item.tmpAbsX = pileGfx.x;
             item.tmpAbsY = pileGfx.y;
-            item.tmpRelScale = pile.contentGraphics.scale.x;
+            item.tmpRelScale = pile.scale();
           });
           store.dispatch(
             createAction.mergePiles([pileId, collidePiles[0].pileId], true)
@@ -2014,7 +2014,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           tempDepileBtn.innerHTML = 'close temp depile';
         }
 
-        if (pile.contentGraphics.scale.x > 1.1) {
+        if (pile.scale() > 1.1) {
           scaleBtn.innerHTML = 'scale down';
         }
 

--- a/src/library.js
+++ b/src/library.js
@@ -1640,7 +1640,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           pile.items.forEach(item => {
             item.tmpAbsX = pileGfx.x;
             item.tmpAbsY = pileGfx.y;
-            item.tmpRelScale = pileGfx.scale.x;
+            item.tmpRelScale = pile.contentGraphics.scale.x;
           });
           store.dispatch(
             createAction.mergePiles([pileId, collidePiles[0].pileId], true)
@@ -2014,7 +2014,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           tempDepileBtn.innerHTML = 'close temp depile';
         }
 
-        if (pile.graphics.scale.x > 1.1) {
+        if (pile.contentGraphics.scale.x > 1.1) {
           scaleBtn.innerHTML = 'scale down';
         }
 

--- a/src/library.js
+++ b/src/library.js
@@ -724,8 +724,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       pile.items.forEach(itemId => {
         itemSrcs.push(items[itemId].src);
         const preview = renderedItems.get(itemId).preview.previewContainer;
-        preview.x = 2;
-        preview.y = 0;
         if (!previewWidth) {
           previewWidth = preview.width - store.getState().previewSpacing;
         }
@@ -736,8 +734,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         .then(newSrc => aggregateRenderer([newSrc]))
         .then(newCover => {
           const cover = new PIXI.Sprite(newCover[0]);
-          cover.x = 2;
-          cover.y = 2;
           const coverRatio = cover.height / cover.width;
           cover.width = previewWidth;
           cover.height = coverRatio * cover.width;

--- a/src/pile.js
+++ b/src/pile.js
@@ -46,7 +46,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
   let isTempDepiled = false;
   let hasCover = false;
   let isPositioning = false;
-  let isScale = false;
+  let isScaling = false;
   let cX;
   let cY;
 
@@ -89,54 +89,49 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
   let borderSizeBase = 0;
 
   const drawBorder = (size = borderSizeBase, mode = '') => {
-    if (!size) {
-      border.clear();
-    } else {
-      if (isPositioning || isScale) {
-        // eslint-disable-next-line no-use-before-define
-        postPilePositionAnimation.set('drawBorder', () => {
-          drawBorder(size, mode);
-        });
-        return;
-      }
-      const rect = itemContainer.getBounds();
+    border.clear();
 
+    if (!size) return;
+
+    if (isPositioning || isScaling) {
       // eslint-disable-next-line no-use-before-define
-      // const currentScale = getScale();
-      // if (currentScale !== 1) {
-      //   rect.width /= currentScale;
-      //   rect.height /= currentScale;
-      // }
-
-      pubSub.publish('updateBBox', id);
-
-      const state = store.getState();
-
-      border.clear();
-
-      // draw black background
-      border.beginFill(state.pileBackgroundColor, state.pileBackgroundOpacity);
-      border.drawRect(
-        bBox.minX - graphics.x - size,
-        bBox.minY - graphics.y - size,
-        rect.width + 2 * size,
-        rect.height + 2 * size
-      );
-      border.endFill();
-
-      // draw border
-      border.lineStyle(
-        size,
-        state[`pileBorderColor${modeToString.get(mode) || ''}`],
-        state[`pileBorderOpacity${modeToString.get(mode) || ''}`]
-      );
-      border.drawRect(
-        bBox.minX - graphics.x - size,
-        bBox.minY - graphics.y - size,
-        rect.width + 2 * size,
-        rect.height + 2 * size
-      );
+      postPilePositionAnimation.set('drawBorder', () => {
+        drawBorder(size, mode);
+      });
+      return;
     }
+
+    const borderBounds = border.getBounds();
+    const contentBounds = contentGraphics.getBounds();
+
+    pubSub.publish('updateBBox', id);
+
+    const state = store.getState();
+
+    const offset = Math.ceil(size / 2) + 1;
+
+    // draw black background
+    border.beginFill(state.pileBackgroundColor, state.pileBackgroundOpacity);
+    border.drawRect(
+      contentBounds.x - borderBounds.x - offset,
+      contentBounds.y - borderBounds.y - offset,
+      contentBounds.width + 2 * offset,
+      contentBounds.height + 2 * offset
+    );
+    border.endFill();
+
+    // draw border
+    border.lineStyle(
+      size,
+      state[`pileBorderColor${modeToString.get(mode) || ''}`],
+      state[`pileBorderOpacity${modeToString.get(mode) || ''}`]
+    );
+    border.drawRect(
+      contentBounds.x - borderBounds.x - offset,
+      contentBounds.y - borderBounds.y - offset,
+      contentBounds.width + 2 * offset,
+      contentBounds.height + 2 * offset
+    );
 
     render();
   };
@@ -295,10 +290,10 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     cY = bBox.minY + (bBox.maxY - bBox.minY) / 2;
   };
 
+  // compute bounding box
   const calcBBox = () => {
-    // compute bounding box
-
-    const scale = contentGraphics.scale.x;
+    // eslint-disable-next-line no-use-before-define
+    const scale = getScale();
 
     let minX = Infinity;
     let minY = Infinity;
@@ -398,18 +393,23 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     animator.add(tweener);
   };
 
-  const positionItems = (itemAlignment, itemRotation, animator, spacing) => {
+  const positionItems = (
+    itemAlignment,
+    itemRotation,
+    animator,
+    previewSpacing
+  ) => {
     isPositioning = true;
     if (hasCover) {
       // matrix
       itemContainer.children.forEach((item, index) => {
         if (index === itemContainer.children.length - 1) return;
 
-        const padding = (item.height + spacing / 2) * (index + 1);
+        const padding = (item.height + previewSpacing / 2) * (index + 1);
 
         animatePositionItems(
           item,
-          2 - spacing / 2,
+          -previewSpacing / 2,
           -padding,
           animator,
           index === itemContainer.children.length - 2
@@ -476,8 +476,8 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
 
         animatePositionItems(
           item,
-          horizontalPadding + 2,
-          verticalPadding + 2,
+          horizontalPadding,
+          verticalPadding,
           animator,
           index === itemContainer.children.length - 1
         );
@@ -550,7 +550,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
       setScale(newScale);
     }
 
-    isScale = true;
+    isScaling = true;
     let duration = 250;
     if (scaleTweener) {
       pubSub.publish('cancelAnimation', scaleTweener);
@@ -567,7 +567,7 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
       getter: getScale,
       setter: setScale,
       onDone: () => {
-        isScale = false;
+        isScaling = false;
         postPilePositionAnimation.forEach(fn => {
           fn();
         });
@@ -680,9 +680,6 @@ const createPile = ({ initialItem, render, id, pubSub, store }) => {
     graphics.buttonMode = true;
     graphics.x = 0;
     graphics.y = 0;
-    // Origin of the items coordinste system relative to the pile
-    initialItem.sprite.anchor.set(0);
-    initialItem.moveTo(2, 2);
 
     graphics
       .on('pointerdown', onPointerDown)


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Change pile scene graph to following:

```
- rootGraphics
  - contentGraphics
    - item comtainer
  - borderGraphics
```

When scale pile, only scale the contentGraphics.

> Why is it necessary?

Upon scaling a pile the border gets unnecessary large. This also prevents us from having an effective scale and border-size encoding at the moment.

Fixes #70 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
