### PR TITLE
Add pile base scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Seperate bewtween pile's base scale and magnification
 - Add `randomOffsetRange` and `randomRotationRange` properties
 - Change pile border to be scale invariant
 - Animate item rotation

--- a/DOCS.md
+++ b/DOCS.md
@@ -178,6 +178,7 @@ The list of all understood properties is given below.
 | lassoStrokeOpacity        | float             | `0.8`                 | must be in [`0`,`1`]                                                          | `false`    |
 | lassoStrokeSize           | int               | `1`                   | must be greater or equal than `1`                                             | `false`    |
 | orderer                   | function          | row-major             | see [`notes`](#notes)                                                         | `true`     |
+| magnifiedPiles                | array             | `[]`                  | the id of current magnified pile                                                 | `true`     |
 | pileBackgroundColor       | string or int     | `0x000000`            |                                                                               | `false`    |
 | pileBackgroundOpacity     | float             | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
 | pileBorderColor           | string or int     | `0x808080`            |                                                                               | `false`    |
@@ -199,7 +200,6 @@ The list of all understood properties is given below.
 | randomOffsetRange         | array             | `[-30, 30]`           | array of two numbers                                                          | `true`     |
 | randomRotationRange       | array             | `[-10, 10]`           | array of two numbers                                                          | `true`     |
 | renderer                  | function          |                       | see [`renderers`](#renderers)                                                 | `false`    |
-| scaledPile                | array             | `[]`                  | the id of current scaled pile                                                 | `true`     |
 | showGrid                  | boolean           | `false`               |                                                                               | `false`    |
 | tempDepileDirection       | string            | `horizontal`          | `horizontal` or `vertical`                                                    | `true`     |
 | tempDepileOneDNum         | number            | `6`                   | the maximum number of items to be temporarily depiled in 1D layout            | `true`     |
@@ -657,12 +657,12 @@ piling.set('previewAggregator', previewAggregator);
 - **De-pile:**
   - While pressing <kbd>SHIFT</kbd>, click on a pile to de-pile it.
   - Right click on a pile to open the context menu. Click on <kbd>depile</kbd> button to de-pile.
-- **Scale a pile:**
-  - While pressing <kbd>ALT</kbd>, click on a pile to automatically scale it up.
-  - While pressing <kbd>ALT</kbd>, click on a scaled-up pile to automatically scale it down.
-  - While pressing <kbd>ALT</kbd>, hover on a pile and scroll to manually scale it. Then click on the background to automatically scale it down.
-  - Right click on a pile to open the context menu. Click on <kbd>scale up</kbd> button to automatically scale the pile up.
-  - Right click on a scaled-up pile to open the context menu. Click on <kbd>scale donw</kbd> button to automatically scale the pile down.
+- **Magnify a pile:**
+  - While pressing <kbd>ALT</kbd>, click on a pile to automatically magnify it.
+  - While pressing <kbd>ALT</kbd>, click on a magnified pile to automatically unmagnify it.
+  - While pressing <kbd>ALT</kbd>, hover on a pile and scroll to manually magnify it. Then click on the background to automatically unmagnify it.
+  - Right click on a pile to open the context menu. Click on <kbd>magnify</kbd> button to automatically magnify the pile.
+  - Right click on a magnified pile to open the context menu. Click on <kbd>unmagnify</kbd> button to automatically unmagnify the pile.
 - **Show grid:**
   - Right click on the background to open the context menu. Click on <kbd>show grid</kbd> button to show the grid.
   - If the grid is shown, right click on the background and click on <kbd>hide grid</kbd> button to hide the grid.

--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -77,7 +77,7 @@ const TEMPLATE = `<ul id="piling-js-context-menu-list">
     <button id="align-button">Align by Grid</button>
   </li>
   <li>
-    <button id="scale-button">Scale Up</button>
+    <button id="magnify-button">Magnify</button>
   </li>
 </ul>`;
 

--- a/src/library.js
+++ b/src/library.js
@@ -136,6 +136,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     },
     lassoStrokeOpacity: true,
     lassoStrokeSize: true,
+    magnifiedPiles: true,
     orderer: true,
     pileBorderColor: {
       set: value => {
@@ -201,7 +202,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       get: 'itemRenderer',
       set: value => [createAction.setItemRenderer(value)]
     },
-    scaledPile: true,
     showGrid: true,
     temporaryDepiledPiles: true,
     tempDepileDirection: true,
@@ -1551,8 +1551,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       renderRaf();
     }
 
-    if (state.scaledPiles !== newState.scaledPiles) {
-      state.scaledPiles
+    if (state.magnifiedPiles !== newState.magnifiedPiles) {
+      state.magnifiedPiles
         .map(scaledPile => pileInstances.get(scaledPile))
         .filter(scaledPileInstance => scaledPileInstance)
         .forEach(scaledPileInstance => {
@@ -1564,7 +1564,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           normalPiles.addChild(scaledPileInstance.graphics);
         });
 
-      newState.scaledPiles
+      newState.magnifiedPiles
         .map(scaledPile => pileInstances.get(scaledPile))
         .filter(scaledPileInstance => scaledPileInstance)
         .forEach(scaledPileInstance => {
@@ -1755,12 +1755,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     renderRaf();
   };
 
-  const scaleBtnClick = (contextMenuElement, pileId) => () => {
+  const pileMagnificationHandler = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
     if (pile.isMagnified) {
-      store.dispatch(createAction.setScaledPiles([]));
+      store.dispatch(createAction.setMagnifiedPiles([]));
     } else {
-      store.dispatch(createAction.setScaledPiles([pileId]));
+      store.dispatch(createAction.setMagnifiedPiles([pileId]));
     }
 
     hideContextMenu(contextMenuElement);
@@ -1843,11 +1843,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             const pile = pileInstances.get(result.pileId);
             if (pile.graphics.isHover) {
               if (pile.isMagnified) {
-                store.dispatch(createAction.setScaledPiles([]));
+                store.dispatch(createAction.setMagnifiedPiles([]));
               } else {
-                store.dispatch(createAction.setScaledPiles([result.pileId]));
+                store.dispatch(createAction.setMagnifiedPiles([result.pileId]));
               }
-              pile.magnifyByToggle();
             }
           });
         } else {
@@ -1860,7 +1859,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         }
       } else {
         store.dispatch(createAction.setFocusedPiles([]));
-        store.dispatch(createAction.setScaledPiles([]));
+        store.dispatch(createAction.setMagnifiedPiles([]));
       }
     }
   };
@@ -1917,7 +1916,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     if (result.length !== 0) {
       if (event.altKey) {
         event.preventDefault();
-        store.dispatch(createAction.setScaledPiles([result[0].pileId]));
+        store.dispatch(createAction.setMagnifiedPiles([result[0].pileId]));
         scalePile(result[0].pileId, normalizeWheel(event).pixelY);
       }
     }
@@ -2015,7 +2014,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const tempDepileBtn = element.querySelector('#temp-depile-button');
     const toggleGridBtn = element.querySelector('#grid-button');
     const alignBtn = element.querySelector('#align-button');
-    const scaleBtn = element.querySelector('#scale-button');
+    const magnifyBtn = element.querySelector('#magnify-button');
 
     // click on pile
     if (clickedOnPile) {
@@ -2036,13 +2035,13 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       } else if (pile.isTempDepiled) {
         depileBtn.setAttribute('disabled', '');
         depileBtn.setAttribute('class', 'inactive');
-        scaleBtn.setAttribute('disabled', '');
-        scaleBtn.setAttribute('class', 'inactive');
+        magnifyBtn.setAttribute('disabled', '');
+        magnifyBtn.setAttribute('class', 'inactive');
         tempDepileBtn.innerHTML = 'close temp depile';
       }
 
       if (pile.isMagnified) {
-        scaleBtn.innerHTML = 'Scale Down';
+        magnifyBtn.innerHTML = 'Unmagnify';
       }
 
       element.style.display = 'block';
@@ -2065,9 +2064,9 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         tempDepileBtnClick(element, pile.id, event),
         false
       );
-      scaleBtn.addEventListener(
+      magnifyBtn.addEventListener(
         'click',
-        scaleBtnClick(element, pile.id),
+        pileMagnificationHandler(element, pile.id),
         false
       );
 
@@ -2088,7 +2087,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     } else {
       depileBtn.style.display = 'none';
       tempDepileBtn.style.display = 'none';
-      scaleBtn.style.display = 'none';
+      magnifyBtn.style.display = 'none';
 
       if (showGrid) {
         toggleGridBtn.innerHTML = 'Hide Grid';

--- a/src/library.js
+++ b/src/library.js
@@ -712,7 +712,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       isFunction(pileOpacity) ? pileOpacity(pile) : pileOpacity
     );
 
-    pileInstance.scale(isFunction(pileScale) ? pileScale(pile) : pileScale);
+    pileInstance.scale(
+      isFunction(pileScale) ? pileScale(pile) : pileScale,
+      false,
+      true
+    );
 
     pileInstance.borderSize(
       isFunction(pileBorderSize) ? pileBorderSize(pile) : pileBorderSize
@@ -1752,7 +1756,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const scaleBtnClick = (contextMenuElement, pileId) => () => {
     const pile = pileInstances.get(pileId);
-    if (pile.scale() > 1) {
+    if (pile.scale() > pile.baseScale) {
       store.dispatch(createAction.setScaledPiles([]));
     } else {
       store.dispatch(createAction.setScaledPiles([pileId]));
@@ -1838,7 +1842,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           results.forEach(result => {
             const pile = pileInstances.get(result.pileId);
             if (pile.graphics.isHover) {
-              if (pile.scale() > 1) {
+              if (pile.scale() > pile.baseScale) {
                 store.dispatch(createAction.setScaledPiles([]));
               } else {
                 store.dispatch(createAction.setScaledPiles([result.pileId]));
@@ -2037,7 +2041,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         tempDepileBtn.innerHTML = 'close temp depile';
       }
 
-      if (pile.scale() > 1) {
+      if (pile.scale() > pile.baseScale) {
         scaleBtn.innerHTML = 'Scale Down';
       }
 

--- a/src/pile.js
+++ b/src/pile.js
@@ -59,6 +59,8 @@ const createPile = ({ initialItems, render, id, pubSub, store }) => {
   let cX;
   let cY;
 
+  let baseScale = 1;
+
   const pubSubSubscribers = [];
   let hoverItemSubscriber;
   let hoverItemEndSubscriber;
@@ -591,11 +593,15 @@ const createPile = ({ initialItems, render, id, pubSub, store }) => {
 
   let scaleTweener;
   // eslint-disable-next-line consistent-return
-  const scale = (newScale, noAnimate) => {
+  const scale = (newScale, noAnimate, updateBaseScale = false) => {
     if (Number.isNaN(+newScale)) return getScale();
 
     if (noAnimate) {
       setScale(newScale);
+    }
+
+    if (updateBaseScale) {
+      baseScale = newScale;
     }
 
     isScaling = true;
@@ -641,7 +647,7 @@ const createPile = ({ initialItems, render, id, pubSub, store }) => {
   };
 
   const scaleToggle = noAnimate => {
-    scale(getScale() > 1 ? 1 : MAX_SCALE, noAnimate);
+    scale(getScale() > baseScale ? baseScale : MAX_SCALE, noAnimate);
   };
 
   const moveTo = (x, y) => {
@@ -883,6 +889,9 @@ const createPile = ({ initialItems, render, id, pubSub, store }) => {
     },
     get cY() {
       return cY;
+    },
+    get baseScale() {
+      return baseScale;
     },
     get bBox() {
       return bBox;

--- a/src/store.js
+++ b/src/store.js
@@ -122,7 +122,7 @@ const [pileItemRotation, setPileItemRotation] = setter(
 
 const [focusedPiles, setFocusedPiles] = setter('focusedPiles', []);
 
-const [scaledPiles, setScaledPiles] = setter('scaledPiles', []);
+const [magnifiedPiles, setMagnifiedPiles] = setter('magnifiedPiles', []);
 
 // 'originalPos' and 'closestPos'
 const [depileMethod, setDepileMethod] = setter('depileMethod', 'originalPos');
@@ -398,7 +398,7 @@ const createStore = () => {
     previewSpacing,
     randomOffsetRange,
     randomRotationRange,
-    scaledPiles,
+    magnifiedPiles,
     showGrid,
     tempDepileDirection,
     tempDepileOneDNum,
@@ -463,7 +463,7 @@ export const createAction = {
   setPileItemAlignment,
   setPileItemRotation,
   setFocusedPiles,
-  setScaledPiles,
+  setMagnifiedPiles,
   setShowGrid,
   setDepileMethod,
   setDepiledPile,


### PR DESCRIPTION
## Description

> What was changed in this pull request?
Add a new property `baseScale` to `pile`. When `pile.scale()` is used, the automatically set scale should act as the base scale.

> Why is it necessary?

Fixes #88 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
