### PR TITLE
Arrange by once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Next
 
 - Add pan&zoom interaction
-- Add a new method `arrangeBy()` for support automatic and data-driven pile arrangements
+- Add `arrangeBy()` and `arrangeByOnce()` for automatic and data-driven pile arrangements
 - Add `randomOffsetRange` and `randomRotationRange` properties
 - Change pile border to be scale invariant
 - Animate item rotation

--- a/DOCS.md
+++ b/DOCS.md
@@ -339,16 +339,17 @@ Position piles with user-specified arrangement method.
 
 `type` and the corresponding `objective` can be one of the following:
 
-| Type      | Objective                                                                               |
-| --------- | --------------------------------------------------------------------------------------- |
-| `null`    | `undefined` _(manual positioning)_                                                      |
-| `'index'` | `function` that returns the linear index                                           |
+| Type      | Objective                                                                             |
+| --------- | ------------------------------------------------------------------------------------- |
+| `null`    | `undefined` _(manual positioning)_                                                    |
+| `'index'` | `function` that returns the linear index                                              |
 | `'ij'`    | `function` that returns the cell (i.e., ij position) the pile should be positioned in |
 | `'xy'`    | `function` that returns the final xy position                                         |
 | `'uv'`    | `function` that returns the final uv position of the canvas                           |
-| `'data'`  | `string`, `object`, `function`, or `array` of the previous types                           |
+| `'data'`  | `string`, `object`, `function`, or `array` of the previous types                      |
 
 **Notes and examples:**
+
 - The signature of the callback function for types `index`, `ij`, `xy` and `uv` should be as follows:
 
   ```javascript
@@ -357,9 +358,11 @@ Position piles with user-specified arrangement method.
     return pilePosition;
   }
   ```
+
 - With `type === 'data'`, `objective` can either be a `string`, `object`, `function`, or an array of the previous types to produce a 1D ordering, 2D scatter plot, or multi-dimensional cluster plot.
 
   - The `objective` object can contain the following properties:
+
     - `property` [type: `string` or `function`]: A function that retrieves that returns a numerical value for an pile's item.
 
       The signature of the callback function looks as follows and must return a numerical value:
@@ -387,20 +390,20 @@ Position piles with user-specified arrangement method.
     - `inverse` [type `boolean` default: `false`]: If `true` the scale will be inverted
 
   - For convenience the following examples are all equivalent:
-    
+
     ```javascript
-      // Define the property via a simple string
-      piling.arrangeBy('data', 'a');
-      // Define the property callback function
-      piling.arrangeBy('data', itemState => itemState.a); // callback function
-      // Define the property callback function as part of the `objective` object
-      piling.arrangeBy('data', { property: itemState => itemState.a });
-      // Explicitly define 
-      piling.arrangeBy('data', ['a']);
+    // Define the property via a simple string
+    piling.arrangeBy('data', 'a');
+    // Define the property callback function
+    piling.arrangeBy('data', itemState => itemState.a); // callback function
+    // Define the property callback function as part of the `objective` object
+    piling.arrangeBy('data', { property: itemState => itemState.a });
+    // Explicitly define
+    piling.arrangeBy('data', ['a']);
     ```
 
   - 1D orderings, 2D scatter plots, or multi-dimensional cluster plots are defined by the number passed to `arrangeBy('data', objectives)`:
-    
+
     ```javascript
       // 1D / linear ordering
       piling.arrangeBy('data', ['a']);
@@ -409,7 +412,11 @@ Position piles with user-specified arrangement method.
       // Multi dimensional cluster plot
       piling.arrangeBy('data', ['a', 'b', 'c', ...]);
     ```
-    
+
+#### `piling.arrangeByOnce(type, objective)`
+
+Same as [`arrangeBy()`](#pilingarrangebytype-objective) but it applies the automatic pile arrangement only once and then switches back to manual pile arrangement.
+
 #### `piling.destroy()`
 
 Destroys the piling instance by disposing all event listeners, the pubSub instance, canvas, and the root PIXI container.

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -54,7 +54,6 @@ const createMatrixPiles = async element => {
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
   });
 
-  pilingJs.arrangeByOnce('data', ['distanceToDiagonal']);
   return pilingJs;
 };
 

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -54,6 +54,7 @@ const createMatrixPiles = async element => {
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
   });
 
+  pilingJs.arrangeByOnce('data', ['distanceToDiagonal']);
   return pilingJs;
 };
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -9,6 +9,9 @@ export const CAMERA_VIEW = new Float32Array([
 export const INITIAL_ARRANGEMENT_TYPE = 'index';
 export const INITIAL_ARRANGEMENT_OBJECTIVE = (pileState, i) => i;
 
+export const LASSO_MIN_DIST = 2;
+export const LASSO_MIN_DELAY = 10;
+
 export const NAVIGATION_MODE_AUTO = 'auto';
 export const NAVIGATION_MODE_PAN_ZOOM = 'panZoom';
 export const NAVIGATION_MODE_SCROLL = 'scroll';

--- a/src/library.js
+++ b/src/library.js
@@ -657,6 +657,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       itemRenderer,
       pileBackgroundColor,
       pileBackgroundOpacity,
+      pileItemAlignment,
+      pileItemRotation,
       previewAggregator,
       previewRenderer,
       previewSpacing
@@ -715,6 +717,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             pubSub,
             store
           });
+          pile.positionItems(
+            pileItemAlignment,
+            pileItemRotation,
+            animator,
+            previewSpacing
+          );
           pileInstances.set(index, pile);
           normalPiles.addChild(pile.graphics);
         });

--- a/src/library.js
+++ b/src/library.js
@@ -33,6 +33,8 @@ import {
   CAMERA_VIEW,
   INITIAL_ARRANGEMENT_TYPE,
   INITIAL_ARRANGEMENT_OBJECTIVE,
+  LASSO_MIN_DIST,
+  LASSO_MIN_DELAY,
   NAVIGATION_MODE_AUTO,
   NAVIGATION_MODE_PAN_ZOOM,
   NAVIGATION_MODE_SCROLL,
@@ -1525,8 +1527,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     return [...mousePosition];
   };
 
-  const LASSO_MIN_DIST = 8;
-  const LASSO_MIN_DELAY = 25;
   let lassoPos = [];
   let lassoPosFlat = [];
   let lassoPrevMousePos;
@@ -1560,8 +1560,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const currMousePos = getMousePos();
 
     if (!lassoPrevMousePos) {
-      lassoPos.push(currMousePos);
-      lassoPosFlat.push(...currMousePos);
+      lassoPos = [currMousePos];
+      lassoPosFlat = [currMousePos[0], currMousePos[1]];
       lassoPrevMousePos = currMousePos;
       lasso.moveTo(...currMousePos);
     } else {
@@ -1574,7 +1574,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       if (d > LASSO_MIN_DIST) {
         lassoPos.push(currMousePos);
-        lassoPosFlat.push(...currMousePos);
+        lassoPosFlat.push(currMousePos[0], currMousePos[1]);
         lassoPrevMousePos = currMousePos;
         if (lassoPos.length > 1) {
           drawlasso();
@@ -2365,6 +2365,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       if (!result) {
         mouseDown = true;
+        lassoEnd();
       }
     }
   };

--- a/src/library.js
+++ b/src/library.js
@@ -116,6 +116,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const properties = {
     aggregateRenderer: true,
     arrangementObjective: true,
+    arrangementOnce: true,
     arrangementType: true,
     backgroundColor: true,
     focusedPiles: true,
@@ -859,6 +860,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       });
 
       isInitialPositioning = false;
+
+      if (store.getState().arrangementOnce) {
+        cancelArrangement();
+      }
     }
 
     store.dispatch(createAction.movePiles(movingPiles));
@@ -1890,6 +1895,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     updateNavigationMode();
   };
 
+  const cancelArrangement = () => {
+    store.dispatch(
+      batchActions([
+        ...set('arrangementType', null, true),
+        ...set('arrangementObjective', null, true),
+        ...set('arrangementOnce', false, true)
+      ])
+    );
+  };
+
   const updated = () => {
     const newState = store.getState();
 
@@ -2197,6 +2212,19 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       batchActions([
         ...set('arrangementType', type, true),
         ...set('arrangementObjective', expandedObjective, true)
+      ])
+    );
+  };
+
+  const arrangeByOnce = (type = null, objective = null) => {
+    const expandedObjective =
+      type === 'data' ? expandArrangementObjective(objective) : objective;
+
+    store.dispatch(
+      batchActions([
+        ...set('arrangementType', type, true),
+        ...set('arrangementObjective', expandedObjective, true),
+        ...set('arrangementOnce', true, true)
       ])
     );
   };
@@ -2793,6 +2821,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     },
     // Methods
     arrangeBy,
+    arrangeByOnce,
     destroy,
     exportState,
     get,

--- a/src/store.js
+++ b/src/store.js
@@ -89,6 +89,8 @@ const [arrangementObjective, setArrangementObjective] = setter(
   'arrangementObjective'
 );
 
+const [arrangementOnce, setArrangementOnce] = setter('arrangementOnce', false);
+
 const [backgroundColor, setBackgroundColor] = setter(
   'backgroundColor',
   0x000000
@@ -392,6 +394,7 @@ const createStore = () => {
   const appReducer = combineReducers({
     aggregateRenderer,
     arrangementObjective,
+    arrangementOnce,
     arrangementType,
     backgroundColor,
     cellAspectRatio,
@@ -482,6 +485,7 @@ export const createAction = {
   movePiles,
   setAggregateRenderer,
   setArrangementObjective,
+  setArrangementOnce,
   setArrangementType,
   setBackgroundColor,
   setCellAspectRatio,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add `piling.arrangeByOnce()` for one time arrangement.

> Why is it necessary?

Address #63 
Implement the missing feature in #86 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
