### PR TITLE
Draw border after position

### DIFF
--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -51,7 +51,8 @@ const createMatrixPiles = async element => {
     items: data,
     itemSize: 64,
     pileCellAlignment: 'center',
-    pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5)
+    pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5),
+    pileBorderSize: pile => pile.items.length - 1
   });
 
   return pilingJs;

--- a/src/library.js
+++ b/src/library.js
@@ -2298,6 +2298,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     if (!hit) {
       normalPiles.addChild(pileGfx);
     }
+
+    previouslyHoveredPiles = [];
   };
 
   let previouslyHoveredPiles = [];

--- a/src/library.js
+++ b/src/library.js
@@ -2347,6 +2347,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     highlightHoveringPiles(pileId);
   };
 
+  const handleDragMovePile = ({ pileId }) => {
+    highlightHoveringPiles(pileId);
+  };
+
   const hideContextMenu = contextMenuElement => {
     contextMenuElement.style.display = 'none';
     rootElement.removeChild(contextMenuElement);
@@ -2778,6 +2782,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     canvas.addEventListener('dblclick', mouseDblClickHandler, false);
 
     pubSub.subscribe('pileDragStart', handleDragStartPile);
+    pubSub.subscribe('pileDragMove', handleDragMovePile);
     pubSub.subscribe('pileDragEnd', handleDragEndPile);
     pubSub.subscribe('animate', handleAnimate);
     pubSub.subscribe('cancelAnimation', handleCancelAnimation);

--- a/src/library.js
+++ b/src/library.js
@@ -184,6 +184,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     pileBorderOpacity: true,
+    pileBorderColorHover: {
+      set: value => {
+        const [color, opacity] = colorToDecAlpha(value, null);
+        const actions = [createAction.setPileBorderColorHover(color)];
+        if (opacity !== null)
+          actions.push(createAction.setPileBorderOpacityHover(opacity));
+        return actions;
+      }
+    },
+    pileBorderOpacityHover: true,
     pileBorderColorFocus: {
       set: value => {
         const [color, opacity] = colorToDecAlpha(value, null);

--- a/src/library.js
+++ b/src/library.js
@@ -1943,6 +1943,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     if (state.piles !== newState.piles) {
       if (state.piles.length !== 0) {
         newState.piles.forEach((pile, id) => {
+          if (pile === state.piles[id]) return;
+
           if (pile.items.length !== state.piles[id].items.length) {
             updatePileItems(pile, id);
             updatedPileItems.push(id);
@@ -2279,7 +2281,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           );
         }
       } else {
-        resetPileBorder();
         // We need to "untranslate" the position of the pile
         const [x, y] = translatePointFromScreen([pile.x, pile.y]);
         store.dispatch(

--- a/src/library.js
+++ b/src/library.js
@@ -2300,30 +2300,30 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     }
   };
 
-  let oldResult = [];
-  let newResult = [];
+  let previouslyHoveredPiles = [];
 
-  const handleHighlightPile = pileId => {
+  const highlightHoveringPiles = pileId => {
     if (store.getState().temporaryDepiledPiles.length) return;
 
-    oldResult = [...newResult];
-    newResult = searchIndex.search(pileInstances.get(pileId).calcBBox());
+    const currentlyHoveredPiles = searchIndex.search(
+      pileInstances.get(pileId).calcBBox()
+    );
 
-    if (oldResult !== []) {
-      oldResult.forEach(collidePile => {
-        if (pileInstances.get(collidePile.id)) {
-          const pile = pileInstances.get(collidePile.id);
-          pile.blur();
-        }
+    previouslyHoveredPiles
+      .map(pile => pileInstances.get(pile.id))
+      .filter(identity)
+      .forEach(pile => {
+        pile.blur();
       });
-    }
 
-    newResult.forEach(collidePile => {
-      if (pileInstances.get(collidePile.id)) {
-        const pile = pileInstances.get(collidePile.id);
+    currentlyHoveredPiles
+      .map(pile => pileInstances.get(pile.id))
+      .filter(identity)
+      .forEach(pile => {
         pile.hover();
-      }
-    });
+      });
+
+    previouslyHoveredPiles = [...currentlyHoveredPiles];
   };
 
   const handleDragStartPile = ({ pileId, event }) => {
@@ -2344,7 +2344,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     store.dispatch(createAction.setMagnifiedPiles([]));
 
     activePile.addChild(pileInstances.get(pileId).graphics);
-    handleHighlightPile(pileId);
+    highlightHoveringPiles(pileId);
   };
 
   const hideContextMenu = contextMenuElement => {

--- a/src/pile.js
+++ b/src/pile.js
@@ -345,7 +345,7 @@ const createPile = (
       if (isTempDepiled) {
         active();
       } else {
-        focus();
+        hover();
       }
 
       render();

--- a/src/pile.js
+++ b/src/pile.js
@@ -181,6 +181,8 @@ const createPile = (
       getCover().then(() => {
         drawBorder();
       });
+    } else {
+      drawBorder();
     }
   };
 
@@ -449,9 +451,8 @@ const createPile = (
         itemSprite.tmpTargetScale = undefined;
         if (isLastOne) {
           isPositioning = false;
-          if (borderSizeBase) {
-            drawBorder();
-          }
+          drawBorder();
+          // console.log(postPilePositionAnimation, borderSizeBase)
           postPilePositionAnimation.forEach(fn => {
             fn();
           });
@@ -640,6 +641,7 @@ const createPile = (
       },
       onDone: () => {
         isScaling = false;
+        drawBorder();
         postPilePositionAnimation.forEach(fn => {
           fn();
         });

--- a/src/pile.js
+++ b/src/pile.js
@@ -123,18 +123,51 @@ const createPile = (
 
   let borderSizeBase = 0;
 
-  const drawBorder = (size = borderSizeBase, currentMode = mode) => {
-    borderGraphics.clear();
+  const setBorderSize = newBorderSize => {
+    borderSizeBase = +newBorderSize;
 
-    if (!size) return;
+    if (getCover()) {
+      // Wait until the cover is rendered
+      getCover().then(() => {
+        drawBorder();
+      });
+    } else {
+      drawBorder();
+    }
+  };
+
+  const getBorderSize = () => {
+    switch (mode) {
+      case MODE_HOVER:
+      case MODE_FOCUS:
+        return borderSizeBase || 1;
+
+      case MODE_ACTIVE:
+        return borderSizeBase || 2;
+
+      case MODE_NORMAL:
+      default:
+        return borderSizeBase;
+    }
+  };
+
+  const drawBorder = () => {
+    const size = getBorderSize();
+
+    if (!size) {
+      borderGraphics.clear();
+      return;
+    }
 
     if (isPositioning || isScaling) {
-      // eslint-disable-next-line no-use-before-define
+      const currentMode = mode;
       postPilePositionAnimation.set('drawBorder', () => {
         drawBorder(size, currentMode);
       });
       return;
     }
+
+    borderGraphics.clear();
 
     const borderBounds = borderGraphics.getBounds();
     const contentBounds = contentGraphics.getBounds();
@@ -172,20 +205,6 @@ const createPile = (
     render();
   };
 
-  const getBorderSize = () => borderSizeBase;
-  const setBorderSize = newBorderSize => {
-    borderSizeBase = +newBorderSize;
-
-    if (getCover()) {
-      // Wait until the cover is rendered
-      getCover().then(() => {
-        drawBorder();
-      });
-    } else {
-      drawBorder();
-    }
-  };
-
   // eslint-disable-next-line consistent-return
   const borderSize = newBorderSize => {
     if (Number.isNaN(+newBorderSize)) return getBorderSize();
@@ -201,19 +220,19 @@ const createPile = (
   const hover = () => {
     if (mode === MODE_HOVER) return;
     mode = MODE_HOVER;
-    drawBorder(borderSizeBase || 1);
+    drawBorder();
   };
 
   const focus = () => {
     if (mode === MODE_FOCUS) return;
     mode = MODE_FOCUS;
-    drawBorder(borderSizeBase || 2);
+    drawBorder();
   };
 
   const active = () => {
     if (mode === MODE_ACTIVE) return;
     mode = MODE_ACTIVE;
-    drawBorder(borderSizeBase || 3);
+    drawBorder();
   };
 
   const onPointerDown = () => {

--- a/src/pile.js
+++ b/src/pile.js
@@ -449,6 +449,9 @@ const createPile = (
         itemSprite.tmpTargetScale = undefined;
         if (isLastOne) {
           isPositioning = false;
+          if (borderSizeBase) {
+            drawBorder();
+          }
           postPilePositionAnimation.forEach(fn => {
             fn();
           });

--- a/src/pile.js
+++ b/src/pile.js
@@ -452,7 +452,6 @@ const createPile = (
         if (isLastOne) {
           isPositioning = false;
           drawBorder();
-          // console.log(postPilePositionAnimation, borderSizeBase)
           postPilePositionAnimation.forEach(fn => {
             fn();
           });

--- a/src/store.js
+++ b/src/store.js
@@ -223,6 +223,16 @@ const [pileBorderOpacity, setPileBorderOpacity] = setter(
   1.0
 );
 
+const [pileBorderColorHover, setPileBorderColorHover] = setter(
+  'pileBorderColorHover',
+  0x808080
+);
+
+const [pileBorderOpacityHover, setPileBorderOpacityHover] = setter(
+  'pileBorderOpacityHover',
+  1.0
+);
+
 const [pileBorderColorFocus, setPileBorderColorFocus] = setter(
   'pileBorderColorFocus',
   0xeee462
@@ -436,9 +446,11 @@ const createStore = () => {
     pileBorderColor,
     pileBorderColorActive,
     pileBorderColorFocus,
+    pileBorderColorHover,
     pileBorderOpacity,
     pileBorderOpacityActive,
     pileBorderOpacityFocus,
+    pileBorderOpacityHover,
     pileBorderSize,
     pileCellAlignment,
     pileContextMenuItems,
@@ -528,9 +540,11 @@ export const createAction = {
   setPileBorderColor,
   setPileBorderColorActive,
   setPileBorderColorFocus,
+  setPileBorderColorHover,
   setPileBorderOpacity,
   setPileBorderOpacityActive,
   setPileBorderOpacityFocus,
+  setPileBorderOpacityHover,
   setPileBorderSize,
   setPileCellAlignment,
   setPileContextMenuItems,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add `pileBorderColorHover`, `pileBorderOpacityHover` to the Redux store.

Add `drawBorder()` when positioning and scaling is done.

> Why is it necessary?

Fixes the problem that the border isn't drawn after positioning piles when we set the border size by pile size.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [ ] CHANGELOG.md updated
