### PR TITLE
Separate pile and preview bg color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Add `previewBorderColor` and `previewBorderOpacity`. Set the default value of `previewBackgroundColor` and `previewBackgroundOpacity` to `'inherit'`
 - Add pan&zoom interaction
 - Add mouse-only lasso support to provide a unified interface for using the lasso in the scroll and pan&zoom mode
 - Add `arrangeBy()` for support automatic and data-driven pile arrangements

--- a/DOCS.md
+++ b/DOCS.md
@@ -203,6 +203,10 @@ The list of all understood properties is given below.
 | pileOpacity                | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
 | pileScale                  | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
 | previewAggregator          | function                |                       | see [`aggregators`](#aggregators)                                             | `true`     |
+| previewBackgroundColor     | string, int             | `'inherit'`           | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| previewBackgroundOpacity   | float                   | `'inherit'`           | must be in [`0`,`1`]                                                          | `false`    |
+| previewBorderColor         | string or int           | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| previewBorderOpacity       | float                   | `0.85`                | must be in [`0`,`1`]                                                          | `false`    |
 | previewRenderer            | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
 | previewSpacing             | number                  | `2`                   | the spacing between 1D previews                                               | `true`     |
 | randomOffsetRange          | array                   | `[-30, 30]`           | array of two numbers                                                          | `true`     |
@@ -341,6 +345,8 @@ The list of all understood properties is given below.
   ```
 
   The function should return a value within `[0, 1]`.
+
+- The default value of `previewBackgroundColor` and `previewBackgroundOpacity` is `'inherit'`, which means that their value inherits from `pileBackgroundColor` and `pileBackgroundOpacity`. If you want preview's background color to be different from pile's, you can set a specific color.
 
 #### `piling.arrangeBy(type, objective)`
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -8,11 +8,10 @@ export const CAMERA_VIEW = new Float32Array([
 
 export const DEFAULT_DARK_MODE = false;
 
-export const DEFAULT_PILE_ITEM_BRIGHTNESS = 0;
-export const DEFAULT_PILE_ITEM_TINT = 0xffffff;
-
 export const EVENT_LISTENER_ACTIVE = { passive: false };
 export const EVENT_LISTENER_PASSIVE = { passive: true };
+
+export const INHERIT = 'inherit';
 
 export const INITIAL_ARRANGEMENT_TYPE = 'index';
 export const INITIAL_ARRANGEMENT_OBJECTIVE = (pileState, i) => i;
@@ -37,5 +36,11 @@ export const NAVIGATION_MODES = [
   NAVIGATION_MODE_PAN_ZOOM,
   NAVIGATION_MODE_SCROLL
 ];
+
+export const DEFAULT_PILE_ITEM_BRIGHTNESS = 0;
+export const DEFAULT_PILE_ITEM_TINT = 0xffffff;
+
+export const DEFAULT_PREVIEW_BACKGROUND_COLOR = INHERIT;
+export const DEFAULT_PREVIEW_BACKGROUND_OPACITY = INHERIT;
 
 export const POSITION_PILES_DEBOUNCE_TIME = 100;

--- a/src/library.js
+++ b/src/library.js
@@ -32,6 +32,7 @@ import {
   CAMERA_VIEW,
   EVENT_LISTENER_ACTIVE,
   EVENT_LISTENER_PASSIVE,
+  INHERIT,
   INITIAL_ARRANGEMENT_TYPE,
   INITIAL_ARRANGEMENT_OBJECTIVE,
   NAVIGATION_MODE_AUTO,
@@ -762,18 +763,15 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       items.map(({ src }) => src)
     ).then(textures => textures.map(createImage));
 
-    const backgroundColor =
-      previewBackgroundColor === 'inherit'
-        ? pileBackgroundColor
-        : previewBackgroundColor;
-    const backgroundOpacity =
-      previewBackgroundOpacity === 'inherit'
-        ? pileBackgroundOpacity
-        : previewBackgroundOpacity;
-
     const previewOptions = {
-      backgroundColor,
-      backgroundOpacity,
+      backgroundColor:
+        previewBackgroundColor === INHERIT
+          ? pileBackgroundColor
+          : previewBackgroundColor,
+      backgroundOpacity:
+        previewBackgroundOpacity === INHERIT
+          ? pileBackgroundOpacity
+          : previewBackgroundOpacity,
       padding: previewSpacing
     };
     const createPreview = texture =>

--- a/src/library.js
+++ b/src/library.js
@@ -734,6 +734,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       itemRenderer,
       previewBackgroundColor,
       previewBackgroundOpacity,
+      pileBackgroundColor,
+      pileBackgroundOpacity,
       pileItemAlignment,
       pileItemRotation,
       previewAggregator,
@@ -759,9 +761,18 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       items.map(({ src }) => src)
     ).then(textures => textures.map(createImage));
 
+    const backgroundColor =
+      previewBackgroundColor === 'inherit'
+        ? pileBackgroundColor
+        : previewBackgroundColor;
+    const backgroundOpacity =
+      previewBackgroundOpacity === 'inherit'
+        ? pileBackgroundOpacity
+        : previewBackgroundOpacity;
+
     const previewOptions = {
-      backgroundColor: previewBackgroundColor,
-      backgroundOpacity: previewBackgroundOpacity,
+      backgroundColor,
+      backgroundOpacity,
       padding: previewSpacing
     };
     const createPreview = texture =>

--- a/src/library.js
+++ b/src/library.js
@@ -232,6 +232,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     previewBackgroundOpacity: true,
+    previewBorderColor: {
+      set: value => {
+        const [color, opacity] = colorToDecAlpha(value, null);
+        const actions = [createAction.setPreviewBorderColor(color)];
+        if (opacity !== null)
+          actions.push(createAction.setPreviewBorderOpacity(opacity));
+        return actions;
+      }
+    },
+    previewBorderOpacity: true,
     randomOffsetRange: true,
     randomRotationRange: true,
     renderer: {
@@ -659,8 +669,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const {
       items,
       itemRenderer,
-      pileBackgroundColor,
-      pileBackgroundOpacity,
+      previewBackgroundColor,
+      previewBackgroundOpacity,
       pileItemAlignment,
       pileItemRotation,
       previewAggregator,
@@ -691,8 +701,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     ).then(textures => textures.map(createImage));
 
     const previewOptions = {
-      backgroundColor: pileBackgroundColor,
-      backgroundOpacity: pileBackgroundOpacity,
+      backgroundColor: previewBackgroundColor,
+      backgroundOpacity: previewBackgroundOpacity,
       padding: previewSpacing
     };
     const createPreview = texture =>

--- a/src/pile.js
+++ b/src/pile.js
@@ -94,14 +94,8 @@ const createPile = (
         const clonedSprite = clonePileItemSprite(item);
         hoverItemContainer.addChild(clonedSprite);
         if (hasPreviewItem(item)) {
-          const {
-            previewBackgroundColor,
-            previewBackgroundOpacity
-          } = store.getState();
-          item.image.drawBackground(
-            previewBackgroundColor,
-            previewBackgroundOpacity
-          );
+          const { previewBorderColor, previewBorderOpacity } = store.getState();
+          item.image.drawBackground(previewBorderColor, previewBorderOpacity);
         }
         render();
       }
@@ -114,8 +108,14 @@ const createPile = (
         hoverItemContainer.removeChildAt(0);
       }
       if (hasPreviewItem(item)) {
-        const { pileBackgroundColor, pileBackgroundOpacity } = store.getState();
-        item.image.drawBackground(pileBackgroundColor, pileBackgroundOpacity);
+        const {
+          previewBackgroundColor,
+          previewBackgroundOpacity
+        } = store.getState();
+        item.image.drawBackground(
+          previewBackgroundColor,
+          previewBackgroundOpacity
+        );
       }
       render();
     }

--- a/src/pile.js
+++ b/src/pile.js
@@ -11,6 +11,8 @@ import createPileItem from './pile-item';
 import createTweener from './tweener';
 import { cloneSprite } from './utils';
 
+import { INHERIT } from './defaults';
+
 export const MAX_MAGNIFICATION = 3;
 export const MODE_NORMAL = Symbol('Normal');
 export const MODE_HOVER = Symbol('Hover');
@@ -115,11 +117,11 @@ const createPile = (
           pileBackgroundOpacity
         } = store.getState();
         const backgroundColor =
-          previewBackgroundColor === 'inherit'
+          previewBackgroundColor === INHERIT
             ? pileBackgroundColor
             : previewBackgroundColor;
         const backgroundOpacity =
-          previewBackgroundOpacity === 'inherit'
+          previewBackgroundOpacity === INHERIT
             ? pileBackgroundOpacity
             : previewBackgroundOpacity;
         item.image.drawBackground(backgroundColor, backgroundOpacity);

--- a/src/pile.js
+++ b/src/pile.js
@@ -110,12 +110,19 @@ const createPile = (
       if (hasPreviewItem(item)) {
         const {
           previewBackgroundColor,
-          previewBackgroundOpacity
+          previewBackgroundOpacity,
+          pileBackgroundColor,
+          pileBackgroundOpacity
         } = store.getState();
-        item.image.drawBackground(
-          previewBackgroundColor,
-          previewBackgroundOpacity
-        );
+        const backgroundColor =
+          previewBackgroundColor === 'inherit'
+            ? pileBackgroundColor
+            : previewBackgroundColor;
+        const backgroundOpacity =
+          previewBackgroundOpacity === 'inherit'
+            ? pileBackgroundOpacity
+            : previewBackgroundOpacity;
+        item.image.drawBackground(backgroundColor, backgroundOpacity);
       }
       render();
     }

--- a/src/store.js
+++ b/src/store.js
@@ -205,11 +205,21 @@ const [previewSpacing, setPreviewSpacing] = setter('previewSpacing', 2);
 
 const [previewBackgroundColor, setPreviewBackgroundColor] = setter(
   'previewBackgroundColor',
-  0xffffff
+  0x000000
 );
 
 const [previewBackgroundOpacity, setPreviewBackgroundOpacity] = setter(
   'previewBackgroundOpacity',
+  0.85
+);
+
+const [previewBorderColor, setPreviewBorderColor] = setter(
+  'previewBorderColor',
+  0xffffff
+);
+
+const [previewBorderOpacity, setPreviewBorderOpacity] = setter(
+  'previewBorderOpacity',
   0.85
 );
 
@@ -453,6 +463,8 @@ const createStore = () => {
     previewAggregator,
     previewBackgroundColor,
     previewBackgroundOpacity,
+    previewBorderColor,
+    previewBorderOpacity,
     previewRenderer,
     previewSpacing,
     randomOffsetRange,
@@ -544,6 +556,8 @@ export const createAction = {
   setPreviewAggregator,
   setPreviewBackgroundColor,
   setPreviewBackgroundOpacity,
+  setPreviewBorderColor,
+  setPreviewBorderOpacity,
   setPreviewRenderer,
   setPreviewSpacing,
   setRandomOffsetRange,

--- a/src/store.js
+++ b/src/store.js
@@ -16,6 +16,8 @@ import {
   DEFAULT_LASSO_STROKE_SIZE,
   DEFAULT_PILE_ITEM_BRIGHTNESS,
   DEFAULT_PILE_ITEM_TINT,
+  DEFAULT_PREVIEW_BACKGROUND_COLOR,
+  DEFAULT_PREVIEW_BACKGROUND_OPACITY,
   NAVIGATION_MODE_AUTO,
   NAVIGATION_MODES
 } from './defaults';
@@ -233,12 +235,12 @@ const [previewSpacing, setPreviewSpacing] = setter('previewSpacing', 2);
 
 const [previewBackgroundColor, setPreviewBackgroundColor] = setter(
   'previewBackgroundColor',
-  'inherit'
+  DEFAULT_PREVIEW_BACKGROUND_COLOR
 );
 
 const [previewBackgroundOpacity, setPreviewBackgroundOpacity] = setter(
   'previewBackgroundOpacity',
-  'inherit'
+  DEFAULT_PREVIEW_BACKGROUND_OPACITY
 );
 
 const [previewBorderColor, setPreviewBorderColor] = setter(

--- a/src/store.js
+++ b/src/store.js
@@ -231,12 +231,12 @@ const [previewSpacing, setPreviewSpacing] = setter('previewSpacing', 2);
 
 const [previewBackgroundColor, setPreviewBackgroundColor] = setter(
   'previewBackgroundColor',
-  0x000000
+  'inherit'
 );
 
 const [previewBackgroundOpacity, setPreviewBackgroundOpacity] = setter(
   'previewBackgroundOpacity',
-  0.85
+  'inherit'
 );
 
 const [previewBorderColor, setPreviewBorderColor] = setter(


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Added `previewBorderColor` and `previewBorderOpacity` to the Redux store.

Now the `previewBackgroundColor` is used when the preview is created, and the `previewBorderColor` is used when hovering on the preview.

> Why is it necessary?

To separate between the pile bg color and the preview bg color.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
