### PR TITLE
Flekschas/mouse only lasso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ### Next
 
 - Add pan&zoom interaction
-- Add a new method `arrangeBy()` for support automatic and data-driven pile arrangements
+- Add mouse-only lasso support to provide a unified interface for using the lasso in the scroll and pan&zoom mode
+- Add `arrangeBy()` for support automatic and data-driven pile arrangements
 - Add `pileItemBrightness` to control the brightness of pile items
 - Add `pileItemTint` to control the [tint of pile items](https://pixijs.download/dev/docs/PIXI.Sprite.html#tint)
 - Add `randomOffsetRange` and `randomRotationRange` properties
+- Change lasso from <kbd>alt</kbd> to <kbd>shift<kbd> + mouse-down + mouse-move
 - Rename `itemOpacity` to `pileItemOpacity` for consistency
 - Change pile border to be scale invariant
 - Animate item rotation

--- a/DOCS.md
+++ b/DOCS.md
@@ -153,79 +153,85 @@ The list of all understood properties is given below.
 
 **Properties:**
 
-| Name                      | Type                    | Default               | Constraints                                                                   | Unsettable |
-| ------------------------- | ----------------------- | --------------------- | ----------------------------------------------------------------------------- | ---------- |
-| aggregateRenderer         | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
-| backgroundColor           | string or int           | `0x000000`            |                                                                               | `false`    |
-| focusedPiles              | array                   | `[]`                  | the id of current focused pile                                                | `true`     |
-| coverAggregator           | function                |                       | see [`aggregators`](#aggregators)                                             | `true`     |
-| depiledPile               | array                   | `[]`                  | the id of the pile to be depiled                                              | `true`     |
-| depileMethod              | string                  | `originalPos`         | `originalPos` or `closestPos`                                                 | `true`     |
-| easing                    | function                | cubicInOut            | see [`notes`](#notes)                                                         | `true`     |
-| gridColor                 | string or int           | `0x787878`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| gridOpacity               | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| items                     | array                   | `[]`                  | see [`data`](#data)                                                           | `false`    |
-| itemSize                  | int                     |                       | number of pixels                                                              | `true`     |
-| itemSizeRange             | array                   | `[0.7, 0.9]`          | array of two numbers between (0, 1)                                           | `true`     |
-| columns                   | int                     | `10`                  | ignored when `itemSize` is defined                                            | `false`    |
-| rowHeight                 | int                     |                       |                                                                               | `true`     |
-| cellAspectRatio           | float                   |                       | ignored when `rowHeight` is defined                                           | `false`    |
-| cellPadding               | int                     |                       |                                                                               | `true`     |
-| lassoFillColor            | string or int           | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| lassoFillOpacity          | float                   | `0.15`                | must be in [`0`,`1`]                                                          | `false`    |
-| lassoStrokeColor          | string or int           | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| lassoStrokeOpacity        | float                   | `0.8`                 | must be in [`0`,`1`]                                                          | `false`    |
-| lassoStrokeSize           | int                     | `1`                   | must be greater or equal than `1`                                             | `false`    |
-| orderer                   | function                | row-major             | see [`notes`](#notes)                                                         | `true`     |
-| magnifiedPiles            | array                   | `[]`                  | the id of current magnified pile                                              | `true`     |
-| navigationMode            | string                  | auto                  | Can be one of auto, panZoom, or scroll                                        | `false`    |
-| pileBackgroundColor       | string or int           | `0x000000`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| pileBackgroundOpacity     | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| pileBorderColor           | string or int           | `0x808080`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| pileBorderOpacity         | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| pileBorderColorSelected   | string or int           | `0xeee462`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| pileBorderOpacitySelected | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| pileBorderColorActive     | string or int           | `0xffa5da`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
-| pileBorderOpacityActive   | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
-| pileBorderSize            | float or function       | 0                     | see [`notes`](#notes)                                                         | `true`     |
-| pileCellAlignment         | string                  | `topLeft`             | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
-| pileContextMenuItems      | array                   | `[]`                  | see _examples_ below                                                          | `true`     |
-| pileItemAlignment         | array or boolean        | `['bottom', 'right']` | array of strings, including `top`, `left`, `bottom`, `right`, or just `false` | `true`     |
-| pileItemBrightness        | string, int or function | `0`                   | must be in [-1,1] where `-1` refers to black and `1` refers to white          | `false`    |
-| pileItemOpacity           | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
-| pileItemRotation          | boolean                 | `false`               | `true` or `false`                                                             | `true`     |
-| pileItemTint              | string, int or function | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `true`     |
-| pileOpacity               | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
-| pileScale                 | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
-| previewAggregator         | function                |                       | see [`aggregators`](#aggregators)                                             | `true`     |
-| previewRenderer           | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
-| previewSpacing            | number                  | `2`                   | the spacing between 1D previews                                               | `true`     |
-| randomOffsetRange         | array                   | `[-30, 30]`           | array of two numbers                                                          | `true`     |
-| randomRotationRange       | array                   | `[-10, 10]`           | array of two numbers                                                          | `true`     |
-| renderer                  | function                |                       | see [`renderers`](#renderers)                                                 | `false`    |
-| showGrid                  | boolean                 | `false`               |                                                                               | `false`    |
-| tempDepileDirection       | string                  | `horizontal`          | `horizontal` or `vertical`                                                    | `true`     |
-| tempDepileOneDNum         | number                  | `6`                   | the maximum number of items to be temporarily depiled in 1D layout            | `true`     |
-| temporaryDepiledPile      | array                   | `[]`                  | the id of the pile to be temporarily depiled                                  | `true`     |
+| Name                       | Type                    | Default               | Constraints                                                                   | Unsettable |
+| -------------------------- | ----------------------- | --------------------- | ----------------------------------------------------------------------------- | ---------- |
+| darkMode                   | boolean                 | `false`               |                                                                               | `false`    |
+| aggregateRenderer          | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
+| backgroundColor            | string or int           | `0x000000`            |                                                                               | `false`    |
+| focusedPiles               | array                   | `[]`                  | the id of current focused pile                                                | `true`     |
+| coverAggregator            | function                |                       | see [`aggregators`](#aggregators)                                             | `true`     |
+| depiledPile                | array                   | `[]`                  | the id of the pile to be depiled                                              | `true`     |
+| depileMethod               | string                  | `originalPos`         | `originalPos` or `closestPos`                                                 | `true`     |
+| easing                     | function                | cubicInOut            | see [`notes`](#notes)                                                         | `true`     |
+| gridColor                  | string or int           | `0x787878`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| gridOpacity                | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| items                      | array                   | `[]`                  | see [`data`](#data)                                                           | `false`    |
+| itemSize                   | int                     |                       | number of pixels                                                              | `true`     |
+| itemSizeRange              | array                   | `[0.7, 0.9]`          | array of two numbers between (0, 1)                                           | `true`     |
+| columns                    | int                     | `10`                  | ignored when `itemSize` is defined                                            | `false`    |
+| rowHeight                  | int                     |                       |                                                                               | `true`     |
+| cellAspectRatio            | float                   |                       | ignored when `rowHeight` is defined                                           | `false`    |
+| cellPadding                | int                     |                       |                                                                               | `true`     |
+| lassoFillColor             | string or int           | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| lassoFillOpacity           | float                   | `0.15`                | must be in [`0`,`1`]                                                          | `false`    |
+| lassoShowStartIndicator    | boolean                 | `true`                |                                                                               | `false`    |
+| lassoStartIndicatorOpacity | float                   | `0.1`                 | must be in [`0`,`1`]                                                          | `false`    |
+| lassoStrokeColor           | string or int           | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| lassoStrokeOpacity         | float                   | `0.8`                 | must be in [`0`,`1`]                                                          | `false`    |
+| lassoStrokeSize            | int                     | `1`                   | must be greater or equal than `1`                                             | `false`    |
+| orderer                    | function                | row-major             | see [`notes`](#notes)                                                         | `true`     |
+| magnifiedPiles             | array                   | `[]`                  | the id of current magnified pile                                              | `true`     |
+| navigationMode             | string                  | auto                  | Can be one of auto, panZoom, or scroll                                        | `false`    |
+| pileBackgroundColor        | string or int           | `0x000000`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| pileBackgroundOpacity      | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| pileBorderColor            | string or int           | `0x808080`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| pileBorderOpacity          | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| pileBorderColorSelected    | string or int           | `0xeee462`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| pileBorderOpacitySelected  | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| pileBorderColorActive      | string or int           | `0xffa5da`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `false`    |
+| pileBorderOpacityActive    | float                   | `1.0`                 | must be in [`0`,`1`]                                                          | `false`    |
+| pileBorderSize             | float or function       | 0                     | see [`notes`](#notes)                                                         | `true`     |
+| pileCellAlignment          | string                  | `topLeft`             | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
+| pileContextMenuItems       | array                   | `[]`                  | see _examples_ below                                                          | `true`     |
+| pileItemAlignment          | array or boolean        | `['bottom', 'right']` | array of strings, including `top`, `left`, `bottom`, `right`, or just `false` | `true`     |
+| pileItemBrightness         | string, int or function | `0`                   | must be in [-1,1] where `-1` refers to black and `1` refers to white          | `false`    |
+| pileItemOpacity            | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
+| pileItemRotation           | boolean                 | `false`               | `true` or `false`                                                             | `true`     |
+| pileItemTint               | string, int or function | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `true`     |
+| pileOpacity                | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
+| pileScale                  | float or function       | 1.0                   | see [`notes`](#notes)                                                         | `true`     |
+| previewAggregator          | function                |                       | see [`aggregators`](#aggregators)                                             | `true`     |
+| previewRenderer            | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
+| previewSpacing             | number                  | `2`                   | the spacing between 1D previews                                               | `true`     |
+| randomOffsetRange          | array                   | `[-30, 30]`           | array of two numbers                                                          | `true`     |
+| randomRotationRange        | array                   | `[-10, 10]`           | array of two numbers                                                          | `true`     |
+| renderer                   | function                |                       | see [`renderers`](#renderers)                                                 | `false`    |
+| showGrid                   | boolean                 | `false`               |                                                                               | `false`    |
+| tempDepileDirection        | string                  | `horizontal`          | `horizontal` or `vertical`                                                    | `true`     |
+| tempDepileOneDNum          | number                  | `6`                   | the maximum number of items to be temporarily depiled in 1D layout            | `true`     |
+| temporaryDepiledPile       | array                   | `[]`                  | the id of the pile to be temporarily depiled                                  | `true`     |
 
 **Examples and Notes:**
 
 - To set a single property do:
 
-  ```
+  ```javascript
   piling.set('propertyName', value);
   ```
 
   To set multiple values at once do:
 
-  ```
+  ```javascript
   piling.set({
     propertyNameA: valueA,
-    propertyNameB: valueB,
+    propertyNameB: valueB
   });
   ```
 
 - A property is considered unsettable if its value can be removed.
+
+- When `darkMode` is `true` we assume that piling.js is used with a black background and the color of certain UI elements are adjusted automatically
+
 - `orderer` is the function for positioning piles, the default function is row-major orderer which looks like this:
 
   ```javascript

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -43,6 +43,7 @@ const createMatrixPiles = async element => {
   const pilingJs = createPilingJs(element);
 
   pilingJs.set({
+    darkMode: true,
     renderer: matrixRenderer,
     previewRenderer,
     aggregateRenderer: coverRenderer,

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -9,6 +9,8 @@ const createPhotoPiles = async element => {
 
   const piling = createPilingJs(element);
 
+  piling.set('darkMode', true);
+
   piling.set('itemSize', 160);
   piling.set('renderer', imageRenderer);
   piling.set('items', data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1176,9 +1176,9 @@
       }
     },
     "@flekschas/utils": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.5.0.tgz",
-      "integrity": "sha512-kroKfYeAuNOlhrP5n7X2KOIx/b1QzHNcEFMzr/6YCapOT2PbJMD8T2AfgwkgHwUj3g1+7Hc0ahWrgTVLGf+twQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.6.0.tgz",
+      "integrity": "sha512-rJLvJV9URF54fu2dcsGEwKXdPGSEXNKs4QeZoOF40SJCTwtXONTiViGLVkDx6u1glBxHae2CpEgiVUUssuJ1Pw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@flekschas/utils": "^0.5.0",
+    "@flekschas/utils": "^0.6.0",
     "camera-2d-simple": "^2.0.1",
     "deep-equal": "^1.1.0",
     "dom-2d-camera": "^1.0.0-rc.5",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -14,6 +14,11 @@ export const INITIAL_ARRANGEMENT_OBJECTIVE = (pileState, i) => i;
 
 export const LASSO_MIN_DIST = 2;
 export const LASSO_MIN_DELAY = 10;
+export const LASSO_SHOW_START_INDICATOR_TIME = 2500;
+export const LASSO_HIDE_START_INDICATOR_TIME = 250;
+export const DEFAULT_LASSO_SHOW_START_INDICATOR = true;
+export const DEFAULT_LASSO_START_INDICATOR_FILL_COLOR = null;
+export const DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY = 0.1;
 
 export const NAVIGATION_MODE_AUTO = 'auto';
 export const NAVIGATION_MODE_PAN_ZOOM = 'panZoom';

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,19 +6,25 @@ export const CAMERA_VIEW = new Float32Array([
   0, 0, 0, 1
 ]);
 
+export const DEFAULT_DARK_MODE = false;
+
 export const DEFAULT_PILE_ITEM_BRIGHTNESS = 0;
 export const DEFAULT_PILE_ITEM_TINT = 0xffffff;
 
 export const INITIAL_ARRANGEMENT_TYPE = 'index';
 export const INITIAL_ARRANGEMENT_OBJECTIVE = (pileState, i) => i;
 
+export const DEFAULT_LASSO_FILL_COLOR = 0xffffff;
+export const DEFAULT_LASSO_FILL_OPACITY = 0.15;
+export const DEFAULT_LASSO_SHOW_START_INDICATOR = true;
+export const DEFAULT_LASSO_START_INDICATOR_OPACITY = 0.1;
+export const DEFAULT_LASSO_STROKE_COLOR = 0xffffff;
+export const DEFAULT_LASSO_STROKE_OPACITY = 0.8;
+export const DEFAULT_LASSO_STROKE_SIZE = 1;
 export const LASSO_MIN_DIST = 2;
 export const LASSO_MIN_DELAY = 10;
 export const LASSO_SHOW_START_INDICATOR_TIME = 2500;
 export const LASSO_HIDE_START_INDICATOR_TIME = 250;
-export const DEFAULT_LASSO_SHOW_START_INDICATOR = true;
-export const DEFAULT_LASSO_START_INDICATOR_FILL_COLOR = null;
-export const DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY = 0.1;
 
 export const NAVIGATION_MODE_AUTO = 'auto';
 export const NAVIGATION_MODE_PAN_ZOOM = 'panZoom';

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -1,0 +1,224 @@
+import {
+  assign,
+  identity,
+  l2PointDist,
+  pipe,
+  throttleAndDebounce,
+  wait,
+  withConstructor,
+  withStaticProperty
+} from '@flekschas/utils';
+import * as PIXI from 'pixi.js';
+
+import { LASSO_MIN_DELAY, LASSO_MIN_DIST } from './defaults';
+
+const lassoStyleEl = document.createElement('style');
+document.head.appendChild(lassoStyleEl);
+
+const lassoStylesheets = lassoStyleEl.sheet;
+
+const scaleInFadeOut = `
+@keyframes scaleInFadeOut {
+  0% {
+    opacity: 0;
+    transform: translate(-50%,-50%) scale(0);
+  }
+  10% {
+    opacity: 1;
+    transform: translate(-50%,-50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%,-50%) scale(1);
+  }
+}
+`;
+
+lassoStylesheets.insertRule(scaleInFadeOut, lassoStylesheets.length);
+
+const indicatorAnimation = '3s scaleInFadeOut backwards';
+
+const createLasso = ({
+  fillColor: initialFillColor,
+  fillOpacity: initialFillOpacity,
+  strokeColor: initialStrokeColor,
+  strokeOpacity: initialStrokeOpacity,
+  strokeSize: initialStrokeSize,
+  onStart: initialOnStart = identity,
+  onDraw: initialOnDraw = identity,
+  isDarkMode: initialIsDarkMode = false
+} = {}) => {
+  let fillColor = initialFillColor;
+  let fillOpacity = initialFillOpacity;
+  let onDraw = initialOnDraw;
+  let onStart = initialOnStart;
+  let strokeColor = initialStrokeColor;
+  let strokeOpacity = initialStrokeOpacity;
+  let strokeSize = initialStrokeSize;
+  let isDarkMode = initialIsDarkMode;
+
+  const lineContainer = new PIXI.Container();
+  const fillContainer = new PIXI.Container();
+  const lineGfx = new PIXI.Graphics();
+  const fillGfx = new PIXI.Graphics();
+
+  lineContainer.addChild(lineGfx);
+  fillContainer.addChild(fillGfx);
+
+  const startIndicator = document.createElement('div');
+  startIndicator.id = 'lasso-start-indicator';
+  startIndicator.style.position = 'absolute';
+  startIndicator.style.zIndex = 1;
+  startIndicator.style.width = '4rem';
+  startIndicator.style.height = '4rem';
+  startIndicator.style.borderRadius = '4rem';
+  startIndicator.style.background = isDarkMode
+    ? 'rgba(255, 255, 255, 0.1)'
+    : 'rgba(0, 0, 0, 0.1)';
+  startIndicator.style.opacity = '0.5';
+  startIndicator.style.transform = 'translate(-50%,-50%) scale(0)';
+
+  let isMouseDown = false;
+  let lassoPos = [];
+  let lassoPosFlat = [];
+  let lassoPrevMousePos;
+
+  const mouseUpHandler = () => {
+    isMouseDown = false;
+  };
+
+  const indicatorMouseDownHandler = () => {
+    isMouseDown = true;
+    clear();
+    onStart();
+  };
+
+  window.addEventListener('mouseup', mouseUpHandler);
+  startIndicator.addEventListener('mousedown', indicatorMouseDownHandler);
+
+  const showStartIndicator = async ([x, y]) => {
+    await wait(0);
+
+    if (isMouseDown) return;
+
+    startIndicator.style.animation = 'none';
+
+    await wait(10);
+
+    startIndicator.style.top = `${y}px`;
+    startIndicator.style.left = `${x}px`;
+    startIndicator.style.animation = indicatorAnimation;
+  };
+
+  const draw = () => {
+    lineGfx.clear();
+    fillGfx.clear();
+    if (lassoPos.length) {
+      lineGfx.lineStyle(strokeSize, strokeColor, strokeOpacity);
+      lineGfx.moveTo(...lassoPos[0]);
+      lassoPos.forEach(pos => {
+        lineGfx.lineTo(...pos);
+        lineGfx.moveTo(...pos);
+      });
+      fillGfx.beginFill(fillColor, fillOpacity);
+      fillGfx.drawPolygon(lassoPosFlat);
+    }
+    onDraw();
+  };
+
+  const extend = currMousePos => {
+    if (!lassoPrevMousePos) {
+      lassoPos = [currMousePos];
+      lassoPosFlat = [currMousePos[0], currMousePos[1]];
+      lassoPrevMousePos = currMousePos;
+    } else {
+      const d = l2PointDist(
+        currMousePos[0],
+        currMousePos[1],
+        lassoPrevMousePos[0],
+        lassoPrevMousePos[1]
+      );
+
+      if (d > LASSO_MIN_DIST) {
+        lassoPos.push(currMousePos);
+        lassoPosFlat.push(currMousePos[0], currMousePos[1]);
+        lassoPrevMousePos = currMousePos;
+        if (lassoPos.length > 1) {
+          draw();
+        }
+      }
+    }
+  };
+
+  const extendDb = throttleAndDebounce(
+    extend,
+    LASSO_MIN_DELAY,
+    LASSO_MIN_DELAY
+  );
+
+  const clear = () => {
+    lassoPos = [];
+    lassoPosFlat = [];
+    lassoPrevMousePos = undefined;
+    draw();
+  };
+
+  const end = () => {
+    const lassoPolygon = [...lassoPosFlat];
+
+    clear();
+
+    return lassoPolygon;
+  };
+
+  const set = ({
+    fillColor: newFillColor = null,
+    fillOpacity: newFillOpacity = null,
+    onDraw: newOnDraw = null,
+    onStart: newOnStart = null,
+    strokeColor: newStrokeColor = null,
+    strokeOpacity: newStrokeOpacity = null,
+    strokeSize: newStrokeSize = null,
+    isDarkMode: newisDarkMode = null
+  } = {}) => {
+    fillColor = newFillColor === null ? fillColor : newFillColor;
+    fillOpacity = newFillOpacity === null ? fillOpacity : newFillOpacity;
+    onDraw = newOnDraw === null ? onDraw : newOnDraw;
+    onStart = newOnStart === null ? onStart : newOnStart;
+    strokeColor = newStrokeColor === null ? strokeColor : newStrokeColor;
+    strokeOpacity =
+      newStrokeOpacity === null ? strokeOpacity : newStrokeOpacity;
+    strokeSize = newStrokeSize === null ? strokeSize : newStrokeSize;
+    isDarkMode = newisDarkMode === null ? isDarkMode : newisDarkMode;
+
+    startIndicator.style.background = isDarkMode
+      ? 'rgba(255, 255, 255, 0.1)'
+      : 'rgba(0, 0, 0, 0.1)';
+  };
+
+  const destroy = () => {
+    window.removeEventListener('mouseup', mouseUpHandler);
+    startIndicator.removeEventListener('mousedown', indicatorMouseDownHandler);
+  };
+
+  const withPublicMethods = () => self =>
+    assign(self, {
+      clear,
+      destroy,
+      end,
+      extend,
+      extendDb,
+      set,
+      showStartIndicator
+    });
+
+  return pipe(
+    withStaticProperty('startIndicator', startIndicator),
+    withStaticProperty('fillContainer', fillContainer),
+    withStaticProperty('lineContainer', lineContainer),
+    withPublicMethods(),
+    withConstructor(createLasso)
+  )({});
+};
+
+export default createLasso;

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -252,6 +252,8 @@ const createLasso = ({
     isLasso = false;
     const lassoPolygon = [...lassoPosFlat];
 
+    extendDb.cancel();
+
     clear();
 
     return lassoPolygon;

--- a/src/library.js
+++ b/src/library.js
@@ -116,6 +116,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     arrangementObjective: true,
     arrangementType: true,
     backgroundColor: true,
+    darkMode: true,
     focusedPiles: true,
     depiledPile: true,
     depileMethod: true,
@@ -158,6 +159,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     lassoFillOpacity: true,
+    lassoShowStartIndicator: true,
+    lassoStartIndicatorOpacity: true,
     lassoStrokeColor: {
       set: value => {
         const [color, opacity] = colorToDecAlpha(value, null);
@@ -535,9 +538,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const updateLasso = () => {
     const {
-      isDarkMode,
+      darkMode,
       lassoFillColor,
       lassoFillOpacity,
+      lassoShowStartIndicator,
+      lassoStartIndicatorOpacity,
       lassoStrokeColor,
       lassoStrokeOpacity,
       lassoStrokeSize
@@ -546,10 +551,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     lasso.set({
       fillColor: lassoFillColor,
       fillOpacity: lassoFillOpacity,
+      showStartIndicator: lassoShowStartIndicator,
+      startIndicatorOpacity: lassoStartIndicatorOpacity,
       strokeColor: lassoStrokeColor,
       strokeOpacity: lassoStrokeOpacity,
       strokeSize: lassoStrokeSize,
-      isDarkMode
+      darkMode
     });
   };
 
@@ -2069,9 +2076,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     }
 
     if (
-      state.isDarkMode !== newState.isDarkMode ||
+      state.darkMode !== newState.darkMode ||
       state.lassoFillColor !== newState.lassoFillColor ||
       state.lassoFillOpacity !== newState.lassoFillOpacity ||
+      state.lassoShowStartIndicator !== newState.lassoShowStartIndicator ||
+      state.lassoStartIndicatorOpacity !==
+        newState.lassoStartIndicatorOpacity ||
       state.lassoStrokeColor !== newState.lassoStrokeColor ||
       state.lassoStrokeOpacity !== newState.lassoStrokeOpacity ||
       state.lassoStrokeSize !== newState.lassoStrokeSize
@@ -2386,7 +2396,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     mousePosition = getRelativeMousePosition(event);
 
     if (isMouseDown) {
-      if (event.altKey || isLasso) {
+      if (event.shiftKey || isLasso) {
         lasso.extendDb(mousePosition.slice());
       } else if (isPanZoom) {
         panZoomHandler(false);
@@ -2771,6 +2781,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     canvas.removeEventListener('wheel', mouseWheelHandler, false);
 
     renderer.destroy(true);
+    lasso.destroy();
 
     if (storeUnsubscribor) {
       storeUnsubscribor();

--- a/src/store.js
+++ b/src/store.js
@@ -6,9 +6,14 @@ import { enableBatching } from 'redux-batched-actions';
 import createOrderer from './orderer';
 
 import {
+  DEFAULT_DARK_MODE,
+  DEFAULT_LASSO_FILL_COLOR,
+  DEFAULT_LASSO_FILL_OPACITY,
   DEFAULT_LASSO_SHOW_START_INDICATOR,
-  DEFAULT_LASSO_START_INDICATOR_FILL_COLOR,
-  DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY,
+  DEFAULT_LASSO_START_INDICATOR_OPACITY,
+  DEFAULT_LASSO_STROKE_COLOR,
+  DEFAULT_LASSO_STROKE_OPACITY,
+  DEFAULT_LASSO_STROKE_SIZE,
   DEFAULT_PILE_ITEM_BRIGHTNESS,
   DEFAULT_PILE_ITEM_TINT,
   NAVIGATION_MODE_AUTO,
@@ -102,7 +107,7 @@ const [backgroundColor, setBackgroundColor] = setter(
   0x000000
 );
 
-const [isDarkMode, setIsDarkMode] = setter('isDarkMode', false);
+const [darkMode, setDarkMode] = setter('darkMode', DEFAULT_DARK_MODE);
 
 const [gridColor, setGridColor] = setter('gridColor', 0x787878);
 
@@ -110,11 +115,14 @@ const [gridOpacity, setGridOpacity] = setter('gridOpacity', 1);
 
 const [showGrid, setShowGrid] = setter('showGrid', false);
 
-const [lassoFillColor, setLassoFillColor] = setter('lassoFillColor', 0xffffff);
+const [lassoFillColor, setLassoFillColor] = setter(
+  'lassoFillColor',
+  DEFAULT_LASSO_FILL_COLOR
+);
 
 const [lassoFillOpacity, setLassoFillOpacity] = setter(
   'lassoFillOpacity',
-  0.15
+  DEFAULT_LASSO_FILL_OPACITY
 );
 
 const [lassoShowStartIndicator, setLassoShowStartIndicator] = setter(
@@ -122,30 +130,25 @@ const [lassoShowStartIndicator, setLassoShowStartIndicator] = setter(
   DEFAULT_LASSO_SHOW_START_INDICATOR
 );
 
-const [lassoStartIndicatorFillColor, setLassoStartIndicatorFillColor] = setter(
-  'lassoStartIndicatorFillColor',
-  DEFAULT_LASSO_START_INDICATOR_FILL_COLOR
-);
-
-const [
-  lassoStartIndicatorFillOpacity,
-  setLassoStartIndicatorFillOpacity
-] = setter(
-  'lassoStartIndicatorFillOpacity',
-  DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY
+const [lassoStartIndicatorOpacity, setLassoStartIndicatorOpacity] = setter(
+  'lassoStartIndicatorOpacity',
+  DEFAULT_LASSO_START_INDICATOR_OPACITY
 );
 
 const [lassoStrokeColor, setLassoStrokeColor] = setter(
   'lassoStrokeColor',
-  0xffffff
+  DEFAULT_LASSO_STROKE_COLOR
 );
 
 const [lassoStrokeOpacity, setLassoStrokeOpacity] = setter(
   'lassoStrokeOpacity',
-  0.8
+  DEFAULT_LASSO_STROKE_OPACITY
 );
 
-const [lassoStrokeSize, setLassoStrokeSize] = setter('lassoStrokeSize', 1);
+const [lassoStrokeSize, setLassoStrokeSize] = setter(
+  'lassoStrokeSize',
+  DEFAULT_LASSO_STROKE_SIZE
+);
 
 const [itemRenderer, setItemRenderer] = setter('itemRenderer');
 
@@ -442,7 +445,7 @@ const createStore = () => {
     focusedPiles,
     gridColor,
     gridOpacity,
-    isDarkMode,
+    darkMode,
     itemRenderer,
     items,
     itemSize,
@@ -450,8 +453,7 @@ const createStore = () => {
     lassoFillColor,
     lassoFillOpacity,
     lassoShowStartIndicator,
-    lassoStartIndicatorFillColor,
-    lassoStartIndicatorFillOpacity,
+    lassoStartIndicatorOpacity,
     lassoStrokeColor,
     lassoStrokeOpacity,
     lassoStrokeSize,
@@ -538,7 +540,7 @@ export const createAction = {
   setFocusedPiles,
   setGridColor,
   setGridOpacity,
-  setIsDarkMode,
+  setDarkMode,
   setItemRenderer,
   setItems,
   setItemSize,
@@ -546,8 +548,7 @@ export const createAction = {
   setLassoFillColor,
   setLassoFillOpacity,
   setLassoShowStartIndicator,
-  setLassoStartIndicatorFillColor,
-  setLassoStartIndicatorFillOpacity,
+  setLassoStartIndicatorOpacity,
   setLassoStrokeColor,
   setLassoStrokeOpacity,
   setLassoStrokeSize,

--- a/src/store.js
+++ b/src/store.js
@@ -99,6 +99,8 @@ const [backgroundColor, setBackgroundColor] = setter(
   0x000000
 );
 
+const [isDarkMode, setIsDarkMode] = setter('isDarkMode', false);
+
 const [gridColor, setGridColor] = setter('gridColor', 0x787878);
 
 const [gridOpacity, setGridOpacity] = setter('gridOpacity', 1);
@@ -419,6 +421,7 @@ const createStore = () => {
     focusedPiles,
     gridColor,
     gridOpacity,
+    isDarkMode,
     itemRenderer,
     items,
     itemSize,
@@ -511,6 +514,7 @@ export const createAction = {
   setFocusedPiles,
   setGridColor,
   setGridOpacity,
+  setIsDarkMode,
   setItemRenderer,
   setItems,
   setItemSize,

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,9 @@ import { enableBatching } from 'redux-batched-actions';
 import createOrderer from './orderer';
 
 import {
+  DEFAULT_LASSO_SHOW_START_INDICATOR,
+  DEFAULT_LASSO_START_INDICATOR_FILL_COLOR,
+  DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY,
   DEFAULT_PILE_ITEM_BRIGHTNESS,
   DEFAULT_PILE_ITEM_TINT,
   NAVIGATION_MODE_AUTO,
@@ -112,6 +115,24 @@ const [lassoFillColor, setLassoFillColor] = setter('lassoFillColor', 0xffffff);
 const [lassoFillOpacity, setLassoFillOpacity] = setter(
   'lassoFillOpacity',
   0.15
+);
+
+const [lassoShowStartIndicator, setLassoShowStartIndicator] = setter(
+  'lassoShowStartIndicator',
+  DEFAULT_LASSO_SHOW_START_INDICATOR
+);
+
+const [lassoStartIndicatorFillColor, setLassoStartIndicatorFillColor] = setter(
+  'lassoStartIndicatorFillColor',
+  DEFAULT_LASSO_START_INDICATOR_FILL_COLOR
+);
+
+const [
+  lassoStartIndicatorFillOpacity,
+  setLassoStartIndicatorFillOpacity
+] = setter(
+  'lassoStartIndicatorFillOpacity',
+  DEFAULT_LASSO_START_INDICATOR_FILL_OPACITY
 );
 
 const [lassoStrokeColor, setLassoStrokeColor] = setter(
@@ -428,6 +449,9 @@ const createStore = () => {
     itemSizeRange,
     lassoFillColor,
     lassoFillOpacity,
+    lassoShowStartIndicator,
+    lassoStartIndicatorFillColor,
+    lassoStartIndicatorFillOpacity,
     lassoStrokeColor,
     lassoStrokeOpacity,
     lassoStrokeSize,
@@ -521,6 +545,9 @@ export const createAction = {
   setItemSizeRange,
   setLassoFillColor,
   setLassoFillOpacity,
+  setLassoShowStartIndicator,
+  setLassoStartIndicatorFillColor,
+  setLassoStartIndicatorFillOpacity,
   setLassoStrokeColor,
   setLassoStrokeOpacity,
   setLassoStrokeSize,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Add support for a mouse-only lasso activation
- Refactor lasso code into its own object type

**Basic behavior:**

1. You click somewhere in the open space
2. A gray circle will appear and slowly fade out
3. If you mouse down again in this grey circle you can start to draw the lasso

![Feb-09-2020 18-40-53](https://user-images.githubusercontent.com/932103/74112557-bf392a80-4b6b-11ea-8f1b-b5e097903868.gif)

**What happens if you leave the circle before it faded out?**

As soon as you mouse out of the circle it will disappear:

![Feb-09-2020 18-40-15](https://user-images.githubusercontent.com/932103/74112552-ae88b480-4b6b-11ea-9b6e-a2818e67d9b1.gif)

**Does this work with Pan&Zoom?**

YES!

![Feb-09-2020 18-41-50](https://user-images.githubusercontent.com/932103/74112567-de37bc80-4b6b-11ea-93e7-bdb98ff62be5.gif)

> Why is it necessary?

Since we support scrolling and pan&zoom the lasso was restricted to ALT + mouse down/move to not interfere with panning. Having to use the keyboard to lasso select piles is tedious.

I started refactoring the lasso as the code got more complex and it's actually quite unrelated from the rest of the code in `library.js`.

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [x] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
