### PR TITLE
Flekschas/animate drop merge with previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 - Add `pileItemBrightness` to control the brightness of pile items
 - Add `pileItemTint` to control the [tint of pile items](https://pixijs.download/dev/docs/PIXI.Sprite.html#tint)
 - Add `randomOffsetRange` and `randomRotationRange` properties
+- Add item rotation animation
+- Add drop-merge animation when using a preview aggregator
 - Rename `itemOpacity` to `pileItemOpacity` for consistency
 - Change pile border to be scale invariant
-- Animate item rotation
 - Unmagnify magnified piles on drag start
 - Fix pile scaling
 - Fix grid drawing to update dynamically upon changes to the grid

--- a/src/library.js
+++ b/src/library.js
@@ -2268,6 +2268,20 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     );
   };
 
+  const animateDropMerge = (sourcePileId, targetPileId) => {
+    const { piles } = store.getState();
+    const x = piles[targetPileId].x;
+    const y = piles[targetPileId].y;
+
+    const onDone = () => {
+      store.dispatch(
+        createAction.mergePiles([sourcePileId, targetPileId], true)
+      );
+    };
+
+    animateMovePileTo(pileInstances.get(sourcePileId), x, y, { onDone });
+  };
+
   let hit;
 
   const pileDragEndHandler = ({ pileId }) => {
@@ -2283,16 +2297,25 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       // only one pile is colliding with the pile
       if (collidePiles.length === 1) {
-        hit = !pileInstances.get(collidePiles[0].id).isTempDepiled;
+        const targetPileId = collidePiles[0].id;
+        hit = !pileInstances.get(targetPileId).isTempDepiled;
         if (hit) {
+          // TODO: The drop merge animation code should be unified
+
+          // This is needed for the drop merge animation of the pile class
           pile.items.forEach(pileItem => {
             pileItem.item.tmpAbsX = pileGfx.x;
             pileItem.item.tmpAbsY = pileGfx.y;
             pileItem.item.tmpRelScale = pile.scale;
           });
-          store.dispatch(
-            createAction.mergePiles([pileId, collidePiles[0].id], true)
-          );
+
+          if (store.getState().previewAggregator) {
+            animateDropMerge(pileId, targetPileId);
+          } else {
+            store.dispatch(
+              createAction.mergePiles([pileId, targetPileId], true)
+            );
+          }
         }
       } else {
         // We need to "untranslate" the position of the pile


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add drop-merge animation when using a preview aggregator

![Feb-09-2020 21-05-34](https://user-images.githubusercontent.com/932103/74116157-498b8980-4b80-11ea-861f-fc1ad0686481.gif)

> Why is it necessary?

The abrupt position change wasn't elegant 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [ ] Examples added or updated
- [x] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
