### PR TITLE
Flekschas/levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1176,9 +1176,9 @@
       }
     },
     "@flekschas/utils": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.14.0.tgz",
-      "integrity": "sha512-XYZG4b9JPzpyxIgnkMUM6RveIaqRsHg8VBBXITqK8yNduaMUSqbSrNeSJ8jg74+TC12SdtfmwuvUC+rZGwppcA=="
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.15.0.tgz",
+      "integrity": "sha512-t8XivGchX3tlzs2vvl0sHCszr94tpalAN2sIHUZfxj2epUo7mxkpPZlkqhRlzkvWBWz8Yt+59qHfZwNthztlAQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1176,9 +1176,9 @@
       }
     },
     "@flekschas/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-t8XivGchX3tlzs2vvl0sHCszr94tpalAN2sIHUZfxj2epUo7mxkpPZlkqhRlzkvWBWz8Yt+59qHfZwNthztlAQ=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-UkvFa+mu+x5nqBaTzF8FxysUKKZ5CM2nnG2GtG4YpVdtDL+2jIKOvCuX4FbiNrthTkgLdDLFp7MWCEO0UP2xbA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@flekschas/utils": "~0.14.0",
+    "@flekschas/utils": "~0.15.0",
     "camera-2d-simple": "~2.0.1",
     "deep-equal": "~1.1.0",
     "dom-2d-camera": "~1.0.0-rc.6",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@flekschas/utils": "~0.15.0",
+    "@flekschas/utils": "~0.16.0",
     "camera-2d-simple": "~2.0.1",
     "deep-equal": "~1.1.0",
     "dom-2d-camera": "~1.0.0-rc.6",

--- a/src/animator.js
+++ b/src/animator.js
@@ -3,18 +3,24 @@ import withRaf from 'with-raf';
 /**
  * Factory function to create an animator
  * @param {function} render - Render funtion
+ * @param {function} pubSub - PubSub messenger
  */
-const createAnimator = render => {
+const createAnimator = (render, pubSub) => {
   const currentTweeners = new Set();
+  let isAnimating = false;
 
   const onCall = () => {
     if (currentTweeners.size) {
       // eslint-disable-next-line no-use-before-define
       animateRaf();
+    } else {
+      if (isAnimating) pubSub.publish('animationEnd');
+      isAnimating = false;
     }
   };
 
   const animate = () => {
+    isAnimating = true;
     const done = [];
     currentTweeners.forEach(tweener => {
       if (tweener.update()) done.push(tweener);

--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -71,6 +71,9 @@ const TEMPLATE = `<ul id="piling-js-context-menu-list">
     <button id="temp-depile-button">Temp. Depile</button>
   </li>
   <li>
+    <button id="browse-separately">Browse Separately</button>
+  </li>
+  <li>
     <button id="grid-button">Show Grid</button>
   </li>
   <li>

--- a/src/grid.js
+++ b/src/grid.js
@@ -13,7 +13,7 @@ import { l1Dist } from './utils';
  * @param {number} cellPadding - The padding between items
  */
 const createGrid = (
-  canvas,
+  { width, height },
   {
     itemSize = null,
     columns = 10,
@@ -24,8 +24,6 @@ const createGrid = (
     cellPadding = 0
   } = {}
 ) => {
-  const { width, height } = canvas.getBoundingClientRect();
-
   let numColumns = columns;
   let numRows = 0;
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -28,7 +28,12 @@ const createGrid = (
 
   let numColumns = columns;
   let numRows = 0;
-  let columnWidth = width / columns;
+
+  if (!+itemSize && !+columns) {
+    numColumns = 10;
+  }
+
+  let columnWidth = width / numColumns;
   let cellWidth = columnWidth - cellPadding * 2;
   let cellHeight = null;
 

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,16 +1,108 @@
-import { pipe, withConstructor, withStaticProperty } from '@flekschas/utils';
+import {
+  createHtmlByTemplate,
+  forEach,
+  pipe,
+  randomString,
+  removeAllChildren,
+  removeLastChild,
+  withConstructor,
+  withReadOnlyProperty,
+  withStaticProperty
+} from '@flekschas/utils';
 
-const createLevels = (store, { maxDepth = 3 } = {}) => {
-  const baseEl = document.createElement('div');
+import createStylesheet from './stylesheet';
+
+const CSS_HASH = randomString(5);
+
+const CSS_PREFIX = `pilingjs-${CSS_HASH}`;
+
+const CSS_BTN_RIGHT_ARROW = [
+  `.${CSS_PREFIX}-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  line-height: 1em;
+  height: 2em;
+  margin-right: -0.25em;
+  padding: 0 0.5em 0 1em;
+  border-radius: 0 0.25em 0.25em 0;
+}`,
+  `li:first-child .${CSS_PREFIX}-btn {
+  padding: 0.5em;
+  border-radius: 0.25em;
+}`,
+  `.${CSS_PREFIX}-btn:focus {
+  outline: none;
+}`,
+  `.${CSS_PREFIX}-btn-right-arrow {
+  position: relative;
+  display: block;
+  border-radius: 0;
+}`,
+  `.${CSS_PREFIX}-btn-right-arrow:after {
+  left: 100%;
+  top: 50%;
+  border: solid transparent;
+  content: '';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  border-color: rgba(0, 0, 0, 0);
+  border-left-color: inherit;
+  border-width: 0.5em;
+  margin-top: -0.5em;
+}`
+];
+
+const createLevels = (store, options = { darkMode: false, maxDepth: 3 }) => {
+  let darkMode = options.darkMode;
+  let maxDepth = options.maxDepth;
+
   const breadcrumbsEl = document.createElement('nav');
+  breadcrumbsEl.style.position = 'absolute';
+  breadcrumbsEl.style.top = 0;
+  breadcrumbsEl.style.left = 0;
+  const breadcrumbsListEl = document.createElement('ol');
+  breadcrumbsListEl.style.display = 'flex';
+  breadcrumbsListEl.style.margin = 0;
+  breadcrumbsListEl.style.padding = 0;
+  breadcrumbsListEl.style.listStyle = 'none';
+  breadcrumbsEl.appendChild(breadcrumbsListEl);
+
+  const stylesheet = createStylesheet();
+  CSS_BTN_RIGHT_ARROW.forEach(stylesheet.addRule);
+
   let prevStates = [];
   let currStateIds = [];
+
+  const styleNavButtons = () => {
+    const textColor = darkMode ? 'white' : 'black';
+    const borderColor = darkMode ? '#333' : '#ccc';
+    const backgroundColor = darkMode ? 'black' : 'white';
+
+    forEach((button, index, array) => {
+      if (index + 1 === array.length) {
+        button.style.background = backgroundColor;
+        button.style.boxShadow = `inset 0 0 0 1px ${borderColor}`;
+        button.style.zIndex = 1;
+        button.className = `${CSS_PREFIX}-btn`;
+      } else {
+        button.style.borderLeftColor = borderColor;
+        button.style.background = borderColor;
+        button.style.zIndex = array.length - index;
+        button.className = `${CSS_PREFIX}-btn ${CSS_PREFIX}-btn-right-arrow`;
+      }
+      button.style.color = textColor;
+    })(breadcrumbsListEl.querySelectorAll('button'));
+  };
 
   const getCurrentStateId = () => currStateIds[currStateIds.length - 1];
 
   const stringifyPileIds = pileIds => pileIds.sort().join('-');
 
-  const getNextState = (currentState, pileIds) => {
+  const getNextState = pileIds => {
+    const currentState = store.export();
     const pileIdIndex = new Set();
 
     pileIds.forEach(pileId => {
@@ -27,6 +119,44 @@ const createLevels = (store, { maxDepth = 3 } = {}) => {
       });
 
     return currentState;
+  };
+
+  const getNumNonEmptyPiles = state =>
+    Object.values(state.piles)
+      .filter(pile => pile.items.length)
+      .reduce((num, pile) => num + pile.items.length, 0);
+
+  const createBreadcrumbTemplate = (state, level) => {
+    const label = level === 0 ? 'Root' : `${level}. Level`;
+    const size = getNumNonEmptyPiles(state);
+    return `<li><button><span><strong>${label}</strong> (${size})</span></button></li>`;
+  };
+
+  const backTo = level => () => {
+    if (level === 0) {
+      leaveAll();
+      return;
+    }
+
+    const currNumPrevStates = prevStates.length;
+
+    while (prevStates.length > level + 1) {
+      removeLastChild(breadcrumbsListEl);
+      currStateIds.pop();
+      prevStates.pop();
+    }
+
+    if (currNumPrevStates > level) {
+      leave();
+    }
+  };
+
+  const addBreadcrumb = (state, level) => {
+    const htmlTemplate = createBreadcrumbTemplate(state, level);
+    const listItemEl = createHtmlByTemplate(htmlTemplate);
+    listItemEl.querySelector('button').addEventListener('click', backTo(level));
+    breadcrumbsListEl.appendChild(listItemEl);
+    styleNavButtons();
   };
 
   const enter = pileIds => {
@@ -46,16 +176,23 @@ const createLevels = (store, { maxDepth = 3 } = {}) => {
     const currentState = store.export();
     prevStates = [...prevStates, currentState];
 
-    const nextState = getNextState(currentState, pileIds);
+    if (prevStates.length === 1) addBreadcrumb(currentState, 0);
+
+    const nextState = getNextState(pileIds);
     store.import(nextState);
-    prevStates = [...currStateIds, nextStateId];
+    currStateIds = [...currStateIds, nextStateId];
+
+    addBreadcrumb(nextState, prevStates.length);
   };
 
   const leave = () => {
-    if (!prevStates.prevStates) {
+    if (!prevStates.length) {
       console.warn("Not allowed! You're already on the root level.");
       return;
     }
+
+    removeLastChild(breadcrumbsListEl);
+    styleNavButtons();
 
     currStateIds.pop();
     const prevState = prevStates.pop();
@@ -63,24 +200,45 @@ const createLevels = (store, { maxDepth = 3 } = {}) => {
   };
 
   const leaveAll = () => {
-    if (!prevStates.prevStates) {
+    if (!prevStates.length) {
       console.warn("Not allowed! You're already on the root level.");
       return;
     }
+
+    removeAllChildren(breadcrumbsListEl);
 
     store.import(prevStates[0]);
     currStateIds = [];
     prevStates = [];
   };
 
+  const ifNotNull = (v, alternative) => (v === null ? alternative : v);
+
+  const set = ({
+    darkMode: newDarkMode = null,
+    maxDepth: newMaxDepth = null
+  } = {}) => {
+    darkMode = ifNotNull(newDarkMode, darkMode);
+    maxDepth = ifNotNull(newMaxDepth, maxDepth);
+    styleNavButtons();
+  };
+
+  const destroy = () => {
+    stylesheet.destroy();
+  };
+
+  styleNavButtons();
+
   return pipe(
-    withStaticProperty('baseEl', baseEl),
-    withStaticProperty('breadcrumbsEl', breadcrumbsEl),
+    withStaticProperty('nav', breadcrumbsEl),
+    withReadOnlyProperty('size', () => prevStates.length),
     withConstructor(createLevels)
   )({
+    destroy,
     enter,
     leave,
-    leaveAll
+    leaveAll,
+    set
   });
 };
 

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,0 +1,87 @@
+import { pipe, withConstructor, withStaticProperty } from '@flekschas/utils';
+
+const createLevels = (store, { maxDepth = 3 } = {}) => {
+  const baseEl = document.createElement('div');
+  const breadcrumbsEl = document.createElement('nav');
+  let prevStates = [];
+  let currStateIds = [];
+
+  const getCurrentStateId = () => currStateIds[currStateIds.length - 1];
+
+  const stringifyPileIds = pileIds => pileIds.sort().join('-');
+
+  const getNextState = (currentState, pileIds) => {
+    const pileIdIndex = new Set();
+
+    pileIds.forEach(pileId => {
+      currentState.piles[pileId].items.forEach(itemId =>
+        pileIdIndex.add(itemId)
+      );
+    });
+
+    // "Empty" not selected piles, i.e., set their items to `[]`
+    Object.keys(currentState.piles)
+      .filter(pileId => !pileIdIndex.has(pileId))
+      .forEach(pileId => {
+        currentState.piles[pileId].items = [];
+      });
+
+    return currentState;
+  };
+
+  const enter = pileIds => {
+    const nextStateId = stringifyPileIds(pileIds);
+    const currStateId = getCurrentStateId();
+
+    if (prevStates.length >= maxDepth) {
+      console.warn(`Not allowed! You reached the maximum depth (${maxDepth})`);
+      return;
+    }
+
+    if (nextStateId === currStateId) {
+      console.warn("Not allowed! You're already on this level.");
+      return;
+    }
+
+    const currentState = store.export();
+    prevStates = [...prevStates, currentState];
+
+    const nextState = getNextState(currentState, pileIds);
+    store.import(nextState);
+    prevStates = [...currStateIds, nextStateId];
+  };
+
+  const leave = () => {
+    if (!prevStates.prevStates) {
+      console.warn("Not allowed! You're already on the root level.");
+      return;
+    }
+
+    currStateIds.pop();
+    const prevState = prevStates.pop();
+    store.import(prevState);
+  };
+
+  const leaveAll = () => {
+    if (!prevStates.prevStates) {
+      console.warn("Not allowed! You're already on the root level.");
+      return;
+    }
+
+    store.import(prevStates[0]);
+    currStateIds = [];
+    prevStates = [];
+  };
+
+  return pipe(
+    withStaticProperty('baseEl', baseEl),
+    withStaticProperty('breadcrumbsEl', breadcrumbsEl),
+    withConstructor(createLevels)
+  )({
+    enter,
+    leave,
+    leaveAll
+  });
+};
+
+export default createLevels;

--- a/src/levels.js
+++ b/src/levels.js
@@ -99,7 +99,13 @@ const createLevels = (store, options = { darkMode: false, maxDepth: 3 }) => {
 
   const getCurrentStateId = () => currStateIds[currStateIds.length - 1];
 
-  const stringifyPileIds = pileIds => pileIds.sort().join('-');
+  const getStateId = pileIds => {
+    const { piles } = store.state;
+    return pileIds
+      .flatMap(pileId => piles[pileId].items)
+      .sort()
+      .join('-');
+  };
 
   const getNextState = pileIds => {
     const currentState = store.export();
@@ -160,7 +166,7 @@ const createLevels = (store, options = { darkMode: false, maxDepth: 3 }) => {
   };
 
   const enter = pileIds => {
-    const nextStateId = stringifyPileIds(pileIds);
+    const nextStateId = getStateId(pileIds);
     const currStateId = getCurrentStateId();
 
     if (prevStates.length >= maxDepth) {

--- a/src/levels.js
+++ b/src/levels.js
@@ -121,14 +121,14 @@ const createLevels = (store, options = { darkMode: false, maxDepth: 3 }) => {
     return currentState;
   };
 
-  const getNumNonEmptyPiles = state =>
+  const countItems = state =>
     Object.values(state.piles)
       .filter(pile => pile.items.length)
       .reduce((num, pile) => num + pile.items.length, 0);
 
   const createBreadcrumbTemplate = (state, level) => {
     const label = level === 0 ? 'Root' : `${level}. Level`;
-    const size = getNumNonEmptyPiles(state);
+    const size = countItems(state);
     return `<li><button><span><strong>${label}</strong> (${size})</span></button></li>`;
   };
 

--- a/src/library.js
+++ b/src/library.js
@@ -30,7 +30,6 @@ import {
 } from '@flekschas/utils';
 
 import createAnimator from './animator';
-
 import createStore, { createAction } from './store';
 
 import {
@@ -869,17 +868,21 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       ([renderedImages, renderedPreviews]) => {
         renderedImages.forEach((image, index) => {
           const { piles } = store.state;
-          const id = items[index].id || index;
+          const pileId = index.toString();
+          const itemId = items[index].id || pileId;
           const preview = renderedPreviews[index];
 
-          const newItem = createItem({ id, image, pubSub }, { preview });
+          const newItem = createItem(
+            { id: itemId, image, pubSub },
+            { preview }
+          );
 
-          renderedItems.set(id, newItem);
+          renderedItems.set(itemId, newItem);
 
           const pile = createPile({
             items: [newItem],
             render: renderRaf,
-            id: index,
+            id: pileId,
             pubSub,
             store
           });
@@ -889,9 +892,9 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             animator,
             previewSpacing
           );
-          pileInstances.set(index, pile);
-          updatePileStyle(piles[index], index);
-          updatePileItemStyle(piles[index], index);
+          pileInstances.set(pileId, pile);
+          updatePileStyle(piles[pileId], pileId);
+          updatePileItemStyle(piles[pileId], pileId);
           normalPiles.addChild(pile.graphics);
         });
         scaleItems();
@@ -1053,8 +1056,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const positionAllPiles = !pileIds.length;
 
     if (positionAllPiles) {
-      const { piles } = store.state;
-      pileIds.splice(0, pileIds.length - 1, ...range(0, piles.length));
+      pileIds.splice(0, 0, ...Object.keys(store.state.piles));
     }
 
     if (items.length === 0) return;
@@ -2233,8 +2235,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     }
 
     if (state.piles !== newState.piles) {
-      if (state.piles.length !== 0) {
-        newState.piles.forEach((pile, id) => {
+      if (Object.keys(state.piles).length !== 0) {
+        Object.entries(newState.piles).forEach(([id, pile]) => {
           if (pile === state.piles[id]) return;
 
           if (pile.items.length !== state.piles[id].items.length) {
@@ -2260,7 +2262,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         state.pileItemBrightness !== newState.pileItemBrightness ||
         state.pileItemTint !== newState.pileItemTint)
     ) {
-      newState.piles.forEach((pile, id) => {
+      Object.entries(newState.piles).forEach(([id, pile]) => {
         updatePileItemStyle(pile, id);
       });
     }
@@ -2271,7 +2273,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         state.pileBorderSize !== newState.pileBorderSize ||
         state.pileScale !== newState.pileScale)
     ) {
-      newState.piles.forEach((pile, id) => {
+      Object.entries(newState.piles).forEach(([id, pile]) => {
         updatePileStyle(pile, id);
       });
     }

--- a/src/library.js
+++ b/src/library.js
@@ -672,6 +672,14 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     });
   };
 
+  const updateLevels = () => {
+    const { darkMode } = store.state;
+
+    levels.set({
+      darkMode
+    });
+  };
+
   const updateLasso = () => {
     const {
       darkMode,
@@ -2587,6 +2595,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       updateHalt();
     }
 
+    if (state.darkMode !== newState.darkMode) {
+      updateLevels();
+    }
+
     if (
       state.darkMode !== newState.darkMode ||
       state.lassoFillColor !== newState.lassoFillColor ||
@@ -3344,6 +3356,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     storeUnsubscribor = store.subscribe(updated);
 
     rootElement.appendChild(scrollContainer);
+    rootElement.appendChild(levels.nav);
     rootElement.appendChild(popup.element);
 
     rootElement.style.overflow = 'hidden';

--- a/src/library.js
+++ b/src/library.js
@@ -2482,10 +2482,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     });
   };
 
-  const exportState = () => store.exportState();
+  const exportState = () => store.export();
 
   const importState = (newState, overwriteState = false) => {
-    store.importState(newState, overwriteState);
+    store.import(newState, overwriteState);
     resetPileBorder();
   };
 

--- a/src/library.js
+++ b/src/library.js
@@ -10,7 +10,6 @@ import {
   capitalize,
   cubicOut,
   debounce,
-  deepClone,
   identity,
   isFunction,
   isPointInPolygon,
@@ -32,7 +31,7 @@ import {
 
 import createAnimator from './animator';
 
-import createStore, { overwrite, softOverwrite, createAction } from './store';
+import createStore, { createAction } from './store';
 
 import {
   CAMERA_VIEW,
@@ -82,7 +81,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const pubSub = createPubSub();
   const store = createStore();
 
-  let state = store.getState();
+  let state = store.state;
 
   let gridMat;
 
@@ -372,7 +371,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const spatialIndex = new RBush();
 
   const drawSpatialIndex = (mousePos, lassoPolygon) => {
-    if (!store.getState().showSpatialIndex) return;
+    if (!store.state.showSpatialIndex) return;
 
     spatialIndexGfx.clear();
     spatialIndexGfx.beginFill(0x00ff00, 0.5);
@@ -556,7 +555,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const vLineNum = Math.ceil(width / layout.columnWidth);
     const hLineNum = Math.ceil(height / layout.rowHeight);
 
-    const { gridColor, gridOpacity } = store.getState();
+    const { gridColor, gridOpacity } = store.state;
 
     gridGfx.clear();
     gridGfx.lineStyle(1, gridColor, gridOpacity);
@@ -585,7 +584,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       orderer,
       pileCellAlignment,
       rowHeight
-    } = store.getState();
+    } = store.state;
 
     layout = createGrid(canvas, {
       cellAspectRatio,
@@ -612,7 +611,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       pileCellAlignment,
       rowHeight,
       showGrid
-    } = store.getState();
+    } = store.state;
 
     layout = createGrid(canvas, {
       itemSize,
@@ -648,7 +647,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const updateHalt = () => {
-    const { darkMode, haltBackgroundOpacity } = store.getState();
+    const { darkMode, haltBackgroundOpacity } = store.state;
 
     popup.set({
       backgroundOpacity: haltBackgroundOpacity,
@@ -666,7 +665,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       lassoStrokeColor,
       lassoStrokeOpacity,
       lassoStrokeSize
-    } = store.getState();
+    } = store.state;
 
     lasso.set({
       fillColor: lassoFillColor,
@@ -697,7 +696,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       if (size < minSize) minSize = size;
     });
 
-    const { itemSizeRange } = store.getState();
+    const { itemSizeRange } = store.state;
     let scaleRange;
 
     const minRange = Math.min(layout.cellWidth, layout.cellHeight);
@@ -748,7 +747,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     pile.animateMoveTo(...transformPointToScreen([x, y]), options);
 
   const updateLayout = oldLayout => {
-    const { arrangementType } = store.getState();
+    const { arrangementType } = store.state;
 
     scaleItems();
 
@@ -777,13 +776,13 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       pileInstances.forEach(pile => {
         if (pile.cover()) {
-          const { pileItemAlignment, pileItemRotation } = store.getState();
+          const { pileItemAlignment, pileItemRotation } = store.state;
 
           pile.positionItems(
             pileItemAlignment,
             pileItemRotation,
             animator,
-            store.getState().previewSpacing
+            store.state.previewSpacing
           );
         }
       });
@@ -805,7 +804,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     createRBush();
 
-    store.getState().focusedPiles.forEach(focusedPile => {
+    store.state.focusedPiles.forEach(focusedPile => {
       pileInstances.get(focusedPile).focus();
     });
 
@@ -826,7 +825,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       previewAggregator,
       previewRenderer,
       previewSpacing
-    } = store.getState();
+    } = store.state;
 
     if (!items.length || !itemRenderer) return null;
 
@@ -869,7 +868,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     return Promise.all([renderImages, renderPreviews]).then(
       ([renderedImages, renderedPreviews]) => {
         renderedImages.forEach((image, index) => {
-          const { piles } = store.getState();
+          const { piles } = store.state;
           const id = items[index].id || index;
           const preview = renderedPreviews[index];
 
@@ -916,7 +915,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const cachedMdPilePos = new Map();
   let cachedMdPilePosDimReducerRun = 0;
   const getPilePositionByMdTransform = async pileId => {
-    const { dimensionalityReducer } = store.getState();
+    const { dimensionalityReducer } = store.state;
 
     if (
       cachedMdPilePos.has(pileId) &&
@@ -944,7 +943,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const getPilePositionByData = (pileId, pileWidth, pileHeight, pileState) => {
-    const { arrangementObjective, arrangementOptions } = store.getState();
+    const { arrangementObjective, arrangementOptions } = store.state;
 
     if (
       arrangementObjective.length > 2 ||
@@ -968,7 +967,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const getPilePosition = async (pileId, init) => {
-    const { arrangementType, arrangementObjective, piles } = store.getState();
+    const { arrangementType, arrangementObjective, piles } = store.state;
 
     const type = init
       ? arrangementType || INITIAL_ARRANGEMENT_TYPE
@@ -1050,11 +1049,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   ];
 
   const positionPiles = async (pileIds = [], { immideate = false } = {}) => {
-    const { items } = store.getState();
+    const { items } = store.state;
     const positionAllPiles = !pileIds.length;
 
     if (positionAllPiles) {
-      const { piles } = store.getState();
+      const { piles } = store.state;
       pileIds.splice(0, pileIds.length - 1, ...range(0, piles.length));
     }
 
@@ -1094,7 +1093,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     isInitialPositioning = false;
 
-    if (store.getState().arrangementOnce) {
+    if (store.state.arrangementOnce) {
       cancelArrangement();
     }
 
@@ -1110,7 +1109,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const positionPilesDb = debounce(positionPiles, POSITION_PILES_DEBOUNCE_TIME);
 
   const positionItems = pileId => {
-    const { pileItemAlignment, pileItemRotation } = store.getState();
+    const { pileItemAlignment, pileItemRotation } = store.state;
 
     pileInstances
       .get(pileId)
@@ -1118,7 +1117,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
         pileItemAlignment,
         pileItemRotation,
         animator,
-        store.getState().previewSpacing
+        store.state.previewSpacing
       );
   };
 
@@ -1128,7 +1127,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       pileItemBrightness,
       pileItemOpacity,
       pileItemTint
-    } = store.getState();
+    } = store.state;
 
     const pileInstance = pileInstances.get(pileId);
 
@@ -1169,7 +1168,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       pileBorderSize,
       pileScale,
       pileVisibilityItems
-    } = store.getState();
+    } = store.state;
 
     pileInstance.animateOpacity(
       isFunction(pileOpacity) ? pileOpacity(pile) : pileOpacity
@@ -1204,7 +1203,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       aggregateRenderer,
       coverAggregator,
       previewAggregator
-    } = store.getState();
+    } = store.state;
 
     if (pileState.items.length === 1) {
       pileInstance.cover(null);
@@ -1261,7 +1260,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const isDimReducerInUse = () => {
-    const { arrangementObjective, arrangementOptions } = store.getState();
+    const { arrangementObjective, arrangementOptions } = store.state;
 
     return (
       arrangementObjective &&
@@ -1286,7 +1285,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           renderedItems.get(itemId)
         );
 
-        if (store.getState().coverAggregator) {
+        if (store.state.coverAggregator) {
           updatePreviewAndCover(pileState, pileInstance);
         } else {
           pileInstance.setItems(itemInstances);
@@ -1503,7 +1502,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const animateDepile = (srcPileId, itemIds, itemPositions = []) => {
-    const { easing } = store.getState();
+    const { easing } = store.state;
     const movingPiles = [];
 
     const srcPile = pileInstances.get(srcPileId);
@@ -1605,7 +1604,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       filterRowNum = rowNum;
     }
 
-    const { piles } = store.getState();
+    const { piles } = store.state;
     const depiledPiles = [];
     const items = [...piles[pileId].items];
     const itemPositions = [];
@@ -1631,7 +1630,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const depileToOriginPos = pileId => {
-    const { piles } = store.getState();
+    const { piles } = store.state;
 
     const items = [...piles[pileId].items];
 
@@ -1645,7 +1644,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     store.dispatch(createAction.depilePiles([depiledPile]));
     blurPrevHoveredPiles();
 
-    if (!store.getState().arrangementType) {
+    if (!store.state.arrangementType) {
       animateDepile(pileId, items);
     }
   };
@@ -1798,7 +1797,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       tempDepileDirection,
       tempDepileOneDNum,
       orderer
-    } = store.getState();
+    } = store.state;
 
     pileIds.forEach(pileId => {
       const pile = pileInstances.get(pileId);
@@ -1863,7 +1862,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const animateMerge = pileIds => {
-    const { easing, piles } = store.getState();
+    const { easing, piles } = store.state;
     let centerX = 0;
     let centerY = 0;
     pileIds.forEach(id => {
@@ -1911,7 +1910,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       arrangementObjective,
       arrangementOptions,
       navigationMode
-    } = store.getState();
+    } = store.state;
 
     let changed = false;
 
@@ -1970,7 +1969,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       arrangementOptions,
       items,
       piles
-    } = store.getState();
+    } = store.state;
 
     const allPiles = pileIds.length >= pileInstances.size;
 
@@ -2080,7 +2079,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   let arrangement2dScales = [];
   const updateArrangement2dScales = () => {
-    const { arrangementObjective } = store.getState();
+    const { arrangementObjective } = store.state;
     const { width, height } = canvas.getBoundingClientRect();
     const rangeMax = [width, height];
 
@@ -2121,7 +2120,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       arrangementOptions,
       dimensionalityReducer,
       items
-    } = store.getState();
+    } = store.state;
 
     if (!dimensionalityReducer) {
       console.warn(
@@ -2164,7 +2163,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const updateArragnementByData = (pileIds, newObjectives) => {
-    const { arrangementObjective, arrangementOptions } = store.getState();
+    const { arrangementObjective, arrangementOptions } = store.state;
 
     updateAggregatedPileValues(pileIds);
 
@@ -2184,7 +2183,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const updateArrangement = async (updatedPileIds, newObjectives) => {
-    const { arrangementType, items } = store.getState();
+    const { arrangementType, items } = store.state;
 
     const pileIds = updatedPileIds.length
       ? updatedPileIds
@@ -2211,7 +2210,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const updated = () => {
-    const newState = store.getState();
+    const newState = store.state;
 
     const stateUpdates = new Set();
 
@@ -2483,24 +2482,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     });
   };
 
-  const exportState = () => {
-    const clonedState = deepClone(state);
-    clonedState.version = { version };
-    return clonedState;
-  };
+  const exportState = () => store.exportState();
 
   const importState = (newState, overwriteState = false) => {
-    if (newState.version !== { version }) {
-      console.warn(
-        `The version of the imported state "${newState.version}" doesn't match the library version "${VERSION}". Use at your own risk!`
-      );
-    }
-
-    delete newState.version;
-
-    if (overwriteState) store.dispatch(overwrite(newState));
-    else store.dispatch(softOverwrite(newState));
-
+    store.importState(newState, overwriteState);
     resetPileBorder();
   };
 
@@ -2607,7 +2592,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const animateDropMerge = (sourcePileId, targetPileId) => {
-    const { piles } = store.getState();
+    const { piles } = store.state;
     const x = piles[targetPileId].x;
     const y = piles[targetPileId].y;
 
@@ -2647,7 +2632,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             pileItem.item.tmpRelScale = pile.scale;
           });
 
-          if (store.getState().previewAggregator) {
+          if (store.state.previewAggregator) {
             animateDropMerge(pileId, targetPileId);
           } else {
             store.dispatch(
@@ -2689,7 +2674,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const highlightHoveringPiles = pileId => {
-    if (store.getState().temporaryDepiledPiles.length) return;
+    if (store.state.temporaryDepiledPiles.length) return;
 
     const currentlyHoveredPiles = spatialIndex.search(calcPileBBox(pileId));
 
@@ -2736,7 +2721,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const depileBtnClick = (contextMenuElement, pileId) => () => {
-    const { depileMethod } = store.getState();
+    const { depileMethod } = store.state;
 
     if (depileMethod === 'originalPos') {
       depileToOriginPos(pileId);
@@ -2748,7 +2733,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const tempDepileBtnClick = (contextMenuElement, pileId) => () => {
-    const { piles, temporaryDepiledPiles } = store.getState();
+    const { piles, temporaryDepiledPiles } = store.state;
     if (piles[pileId].items.length > 1) {
       let temp = [...temporaryDepiledPiles];
       if (temp.includes(pileId)) {
@@ -2762,7 +2747,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const toggleGridBtnClick = contextMenuElement => () => {
-    const { showGrid } = store.getState();
+    const { showGrid } = store.state;
 
     store.dispatch(createAction.setShowGrid(!showGrid));
 
@@ -2860,7 +2845,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       if (results.length !== 0) {
         if (event.shiftKey) {
-          const { depileMethod } = store.getState();
+          const { depileMethod } = store.state;
           if (depileMethod === 'originalPos') {
             depileToOriginPos(results[0].id);
           } else if (depileMethod === 'cloestPos') {
@@ -2898,7 +2883,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const currMousePos = getMousePosition(event);
     const currMousePosRel = translatePointFromScreen(currMousePos);
 
-    const { temporaryDepiledPiles, piles } = store.getState();
+    const { temporaryDepiledPiles, piles } = store.state;
 
     const result = spatialIndex.search({
       minX: currMousePosRel[0],
@@ -3015,7 +3000,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     if (event.altKey) return;
 
-    const { pileContextMenuItems, showGrid } = store.getState();
+    const { pileContextMenuItems, showGrid } = store.state;
 
     event.preventDefault();
 
@@ -3107,7 +3092,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           () => {
             item.callback({
               id: pile.id,
-              ...store.getState().piles[pile.id]
+              ...store.state.piles[pile.id]
             });
             if (!item.keepOpen) closeContextMenu();
           },
@@ -3149,7 +3134,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const startAnimationHandler = tweener => {
-    tweener.setEasing(store.getState().easing);
+    tweener.setEasing(store.state.easing);
     animator.add(tweener);
   };
 

--- a/src/library.js
+++ b/src/library.js
@@ -1385,6 +1385,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const updatePileItems = (pileState, id) => {
     if (pileInstances.has(id)) {
       const pileInstance = pileInstances.get(id);
+
       if (pileState.items.length === 0) {
         deletePileHandler(id);
       } else {
@@ -2000,9 +2001,14 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
   const createPileHandler = (pileId, pileState) => {
     const [x, y] = transformPointToScreen([pileState.x, pileState.y]);
+
+    const items = pileState.items.length
+      ? pileState.items.map(itemId => renderedItems.get(itemId))
+      : [renderedItems.get(pileId)];
+
     const newPile = createPile(
       {
-        items: [renderedItems.get(pileId)],
+        items,
         render: renderRaf,
         id: pileId,
         pubSub,

--- a/src/pile.js
+++ b/src/pile.js
@@ -99,7 +99,7 @@ const createPile = (
         const clonedSprite = clonePileItemSprite(item);
         hoverItemContainer.addChild(clonedSprite);
         if (hasPreviewItem(item)) {
-          const { previewBorderColor, previewBorderOpacity } = store.getState();
+          const { previewBorderColor, previewBorderOpacity } = store.state;
           item.image.drawBackground(previewBorderColor, previewBorderOpacity);
         }
         render();
@@ -118,7 +118,7 @@ const createPile = (
           previewBackgroundOpacity,
           pileBackgroundColor,
           pileBackgroundOpacity
-        } = store.getState();
+        } = store.state;
         const backgroundColor =
           previewBackgroundColor === INHERIT
             ? pileBackgroundColor
@@ -184,7 +184,7 @@ const createPile = (
     const borderBounds = borderGraphics.getBounds();
     const contentBounds = contentGraphics.getBounds();
 
-    const state = store.getState();
+    const state = store.state;
 
     const offset = Math.ceil(size / 2) + 1;
 
@@ -580,7 +580,7 @@ const createPile = (
         );
       });
     } else {
-      const { randomOffsetRange, randomRotationRange } = store.getState();
+      const { randomOffsetRange, randomRotationRange } = store.state;
       let num = 0;
       newItems.forEach(pileItem => {
         num++;
@@ -965,7 +965,7 @@ const createPile = (
       const width = previewItemContainer.children.length
         ? previewItemContainer.width
         : normalItemContainer.width;
-      cover.width = width - store.getState().previewSpacing;
+      cover.width = width - store.state.previewSpacing;
       cover.height = coverRatio * cover.width;
     });
   };

--- a/src/store.js
+++ b/src/store.js
@@ -362,17 +362,23 @@ const [
 ] = setter('randomRotationRange', [-10, 10]);
 
 // reducer
-const piles = (previousState = [], action) => {
+const piles = (previousState = {}, action) => {
   switch (action.type) {
     case 'INIT_PILES': {
-      return new Array(action.payload.itemLength).fill().map((x, id) => ({
-        items: [id],
-        x: null,
-        y: null
-      }));
+      return new Array(action.payload.itemLength)
+        .fill()
+        .reduce((newState, _, id) => {
+          newState[id] = {
+            items: [id.toString()],
+            x: null,
+            y: null
+          };
+          return newState;
+        }, {});
     }
+
     case 'MERGE_PILES': {
-      const newState = [...previousState];
+      const newState = { ...previousState };
 
       if (action.payload.isDropped) {
         const source = action.payload.pileIds[0];
@@ -391,7 +397,7 @@ const piles = (previousState = [], action) => {
           y: null
         };
       } else {
-        const target = Math.min(...action.payload.pileIds);
+        const target = Math.min.apply([], action.payload.pileIds).toString();
         const sourcePileIds = action.payload.pileIds.filter(
           id => id !== target
         );
@@ -424,8 +430,9 @@ const piles = (previousState = [], action) => {
       }
       return newState;
     }
+
     case 'MOVE_PILES': {
-      const newState = [...previousState];
+      const newState = { ...previousState };
       action.payload.movingPiles.forEach(({ id, x, y }) => {
         newState[id] = {
           ...newState[id],
@@ -435,6 +442,7 @@ const piles = (previousState = [], action) => {
       });
       return newState;
     }
+
     case 'DEPILE_PILES': {
       const depilePiles = action.payload.piles.filter(
         pile => pile.items.length > 1
@@ -442,7 +450,7 @@ const piles = (previousState = [], action) => {
 
       if (!depilePiles.length) return previousState;
 
-      const newState = [...previousState];
+      const newState = { ...previousState };
 
       depilePiles.forEach(pile => {
         pile.items.forEach(itemId => {
@@ -456,6 +464,7 @@ const piles = (previousState = [], action) => {
       });
       return newState;
     }
+
     default:
       return previousState;
   }

--- a/src/store.js
+++ b/src/store.js
@@ -621,7 +621,7 @@ const createStore = () => {
 
   const exportState = () => {
     const clonedState = deepClone(reduxStore.getState());
-    clonedState.version = { version };
+    clonedState.version = version;
     return clonedState;
   };
 

--- a/src/store.js
+++ b/src/store.js
@@ -612,8 +612,8 @@ const createStore = () => {
     withForwardedMethod('dispatch', reduxStore.dispatch),
     withForwardedMethod('subscribe', reduxStore.subscribe)
   )({
-    exportState,
-    importState
+    export: exportState,
+    import: importState
   });
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -192,8 +192,6 @@ const [previewAggregator, setPreviewAggregator] = setter('previewAggregator');
 
 const [coverAggregator, setCoverAggregator] = setter('coverAggregator');
 
-const [items, setItems] = setter('items', []);
-
 const [orderer, setOrderer] = setter('orderer', createOrderer().rowMajor);
 
 // Grid
@@ -361,21 +359,35 @@ const [
   setRandomRotationRange
 ] = setter('randomRotationRange', [-10, 10]);
 
-// reducer
+const items = (previousState = {}, action) => {
+  switch (action.type) {
+    case 'SET_ITEMS':
+      return action.payload.items.reduce((newState, item, index) => {
+        newState[index || item.id] = item;
+        return newState;
+      }, {});
+
+    default:
+      return previousState;
+  }
+};
+
+const setItems = newItems => ({
+  type: 'SET_ITEMS',
+  payload: { items: newItems }
+});
+
 const piles = (previousState = {}, action) => {
   switch (action.type) {
-    case 'INIT_PILES': {
-      return new Array(action.payload.itemLength)
-        .fill()
-        .reduce((newState, _, id) => {
-          newState[id] = {
-            items: [id.toString()],
-            x: null,
-            y: null
-          };
-          return newState;
-        }, {});
-    }
+    case 'INIT_PILES':
+      return action.payload.newItems.reduce((newState, item, index) => {
+        newState[index] = {
+          items: [item.id || index.toString()],
+          x: null,
+          y: null
+        };
+        return newState;
+      }, {});
 
     case 'MERGE_PILES': {
       const newState = { ...previousState };
@@ -471,9 +483,9 @@ const piles = (previousState = {}, action) => {
 };
 
 // action
-const initPiles = itemLength => ({
+const initPiles = newItems => ({
   type: 'INIT_PILES',
-  payload: { itemLength }
+  payload: { newItems }
 });
 
 const mergePiles = (pileIds, isDropped) => ({

--- a/src/stylesheet.js
+++ b/src/stylesheet.js
@@ -1,0 +1,28 @@
+const createStylesheet = () => {
+  const styleEl = document.createElement('style');
+  document.head.appendChild(styleEl);
+
+  const stylesheets = styleEl.sheet;
+
+  const addRule = rule => {
+    const currentNumRules = stylesheets.length;
+    stylesheets.insertRule(rule, currentNumRules);
+    return currentNumRules;
+  };
+
+  const removeRule = index => {
+    stylesheets.deleteRule(index);
+  };
+
+  const destroy = () => {
+    document.head.removeChild(styleEl);
+  };
+
+  return {
+    addRule,
+    destroy,
+    removeRule
+  };
+};
+
+export default createStylesheet;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Added the functionality to browse piles in isolation

![inception](https://user-images.githubusercontent.com/932103/75103296-f6292a80-55c6-11ea-99b5-bff1b7f8f50d.gif)

> Why is it necessary?

One way of browsing piles at scale

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [ ] Documentation added or updated
- [ ] Examples added or updated
- [x] Screenshot or GIF included (e.g. new or changed visualization features)
- [ ] CHANGELOG.md updated
