### PR TITLE
pileItemAlignment -> pileItemOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Replace `pileItemAlignment` with `pileItemOffset`
 - Add a joy plot like example for monthly temperature distributions in Berlin Tempelhofer Feld
 - Add support for dynamically re-render the items either when their data changes or when the renderer changes
 - Add an example of _perfectly overlapping_ piles using a subset of Google Quickdraw Dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next
 
-- Replace `pileItemAlignment` with `pileItemOffset`
+- Remove `randomOffsetRange` and `randomRotationRange`
+- Replace `pileItemAlignment` with `pileItemOffset`. Allow `pileItemOffset` and `pileItemRotation` to either be a static value or a callback function
 - Add a joy plot like example for monthly temperature distributions in Berlin Tempelhofer Feld
 - Add support for dynamically re-render the items either when their data changes or when the renderer changes
 - Add an example of _perfectly overlapping_ piles using a subset of Google Quickdraw Dataset

--- a/DOCS.md
+++ b/DOCS.md
@@ -200,7 +200,7 @@ The list of all understood properties is given below.
 | pileBorderSize             | float or function       | `0`                   | see [`notes`](#notes)                                                         | `true`     |
 | pileCellAlignment          | string                  | topLeft               | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
 | pileContextMenuItems       | array                   | `[]`                  | see _examples_ below                                                          | `true`     |
-| pileItemAlignment          | array or boolean        | `['bottom', 'right']` | array of strings, including `top`, `left`, `bottom`, `right`, or just `false` | `true`     |
+| pileItemOffset          | array or function        | `[5, 5]`                | see [`notes`](#notes)                                                         | `true`     |
 | pileItemBrightness         | string, int or function | `0`                   | must be in [-1,1] where `-1` refers to black and `1` refers to white          | `false`    |
 | pileItemOpacity            | float or function       | `1.0`                 | see [`notes`](#notes)                                                         | `true`     |
 | pileItemRotation           | boolean                 | `false`               | `true` or `false`                                                             | `true`     |
@@ -308,6 +308,18 @@ The list of all understood properties is given below.
     }
   ]);
   ```
+
+- `pileItemOffset` can be set to an array or a callback function. The array should either be a tuple specifying the x and y offset in pixel, or be empty to indicate randomly offset. E.g.,
+
+  ```javascript
+  // Align items in y-axis
+  piling.set('pileItemOffset', [0, 5]);
+
+  // Random alignment
+  piling.set('pileItemOffset', []);
+  ```
+
+  See the next note for the signature of the callback function ⬇️
 
 - `pileBorderSize`, `pileOpacity` and `pileScale` can be set to a static float value, or the user can specify a callback function to dynamically style piles. E.g.,
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -200,10 +200,10 @@ The list of all understood properties is given below.
 | pileBorderSize             | float or function       | `0`                   | see [`notes`](#notes)                                                         | `true`     |
 | pileCellAlignment          | string                  | topLeft               | `topLeft`, `topRight`, `bottomLeft`, `bottomRight` or `center`                | `true`     |
 | pileContextMenuItems       | array                   | `[]`                  | see _examples_ below                                                          | `true`     |
-| pileItemOffset          | array or function        | `[5, 5]`                | see [`notes`](#notes)                                                         | `true`     |
 | pileItemBrightness         | string, int or function | `0`                   | must be in [-1,1] where `-1` refers to black and `1` refers to white          | `false`    |
+| pileItemOffset          | array or function        | `[5, 5]`                | see [`notes`](#notes)                                                         | `true`     |
 | pileItemOpacity            | float or function       | `1.0`                 | see [`notes`](#notes)                                                         | `true`     |
-| pileItemRotation           | boolean                 | `false`               | `true` or `false`                                                             | `true`     |
+| pileItemRotation           | float or function        | `0`                  | see [`notes`](#notes)                                                         | `true`     |
 | pileItemTint               | string, int or function | `0xffffff`            | can be HEX, RGB, or RGBA string or hexadecimal value                          | `true`     |
 | pileOpacity                | float or function       | `1.0`                 | see [`notes`](#notes)                                                         | `true`     |
 | pileScale                  | float or function       | `1.0`                 | see [`notes`](#notes)                                                         | `true`     |
@@ -215,8 +215,6 @@ The list of all understood properties is given below.
 | previewBorderOpacity       | float                   | `0.85`                | must be in [`0`,`1`]                                                          | `false`    |
 | previewRenderer            | function                |                       | see [`renderers`](#renderers)                                                 | `true`     |
 | previewSpacing             | number                  | `2`                   | the spacing between 1D previews                                               | `true`     |
-| randomOffsetRange          | array                   | `[-30, 30]`           | array of two numbers                                                          | `true`     |
-| randomRotationRange        | array                   | `[-10, 10]`           | array of two numbers                                                          | `true`     |
 | renderer                   | function                |                       | see [`renderers`](#renderers)                                                 | `false`    |
 | showGrid                   | boolean                 | `false`               |                                                                               | `false`    |
 | tempDepileDirection        | string                  | horizontal            | horizontal or vertical                                                        | `true`     |
@@ -309,18 +307,6 @@ The list of all understood properties is given below.
   ]);
   ```
 
-- `pileItemOffset` can be set to an array or a callback function. The array should either be a tuple specifying the x and y offset in pixel, or be empty to indicate randomly offset. E.g.,
-
-  ```javascript
-  // Align items in y-axis
-  piling.set('pileItemOffset', [0, 5]);
-
-  // Random alignment
-  piling.set('pileItemOffset', []);
-  ```
-
-  See the next note for the signature of the callback function ⬇️
-
 - `pileBorderSize`, `pileOpacity` and `pileScale` can be set to a static float value, or the user can specify a callback function to dynamically style piles. E.g.,
 
   ```javascript
@@ -340,7 +326,16 @@ The list of all understood properties is given below.
   }
   ```
 
-- `pileItemBrightness`, `pileItemOpacity`, and `pileItemTint` can either be set to a static value or a callback function to dynamically style items. E.g.,
+- `pileItemOffset` can be set to an array or a callback function. The array should be a tuple specifying the x and y offset in pixel. E.g.,
+
+  ```javascript
+  // Align items in y-axis
+  piling.set('pileItemOffset', [0, 5]);
+  ```
+
+  See the next note for the signature of the callback function ⬇️
+
+- `pileItemBrightness`, `pileItemOpacity`, `pileItemRotation` and `pileItemTint` can either be set to a static value or a callback function to dynamically style items. E.g.,
 
   ```javascript
   // Set to a static number

--- a/examples/drawings.js
+++ b/examples/drawings.js
@@ -32,7 +32,7 @@ const createDrawingPiles = async element => {
     items: testData,
     itemSize: 32,
     cellPadding: 16,
-    pileItemAlignment: 'overlap',
+    pileItemOffset: [0, 0],
     pileBackgroundColor: 'rgba(255, 255, 255, 0.66)',
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 2),
     pileVisibilityItems: pile => pile.items.length === 1,

--- a/examples/joy-plot.js
+++ b/examples/joy-plot.js
@@ -60,7 +60,7 @@ const createSvgLinesPiles = async element => {
     renderer: svgRenderer,
     items,
     columns: 12,
-    pileItemAlignment: ['bottom'],
+    pileItemOffset: [0, 5],
     pileItemBrightness: (_, i, pile) =>
       Math.min(0.5, 0.01 * (pile.items.length - i - 1)),
     pileBackgroundColor: 'rgba(255, 255, 255, 0.66)',

--- a/examples/joy-plot.js
+++ b/examples/joy-plot.js
@@ -68,7 +68,7 @@ const createSvgLinesPiles = async element => {
     renderer: svgRenderer,
     items,
     columns: 12,
-    pileItemOffset: [0, 5],
+    pileItemOffset: [-1, 5],
     pileItemBrightness: (_, i, pile) =>
       Math.min(0.5, 0.01 * (pile.items.length - i - 1)),
     pileBackgroundColor: 'rgba(255, 255, 255, 0.66)',

--- a/examples/lines.js
+++ b/examples/lines.js
@@ -37,7 +37,7 @@ const createSvgLinesPiles = element => {
     items: data,
     pileItemOpacity: (item, i, pile) =>
       (1 / pile.items.length) * (2 / 3) + 1 / 3,
-    pileItemAlignment: 'overlap',
+    pileItemOffset: [0, 0],
     pileBackgroundColor: 'rgba(255, 255, 255, 0.66)',
     backgroundColor: '#ffffff',
     lassoFillColor: '#000000',

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -19,8 +19,11 @@ const createPhotoPiles = async element => {
 
   piling.set('pileBorderSize', pile => pile.items.length - 1);
 
-  piling.set('pileItemOffset', () => [Math.random() * 10, Math.random() * 10]);
-  piling.set('pileItemRotation', () => Math.random() * 10);
+  piling.set('pileItemOffset', () => [
+    Math.random() * 20 - 10,
+    Math.random() * 20 - 10
+  ]);
+  piling.set('pileItemRotation', () => Math.random() * 20 - 10);
 
   return [piling];
 };

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -19,8 +19,8 @@ const createPhotoPiles = async element => {
 
   piling.set('pileBorderSize', pile => pile.items.length - 1);
 
-  piling.set('pileItemOffset', []);
-  piling.set('pileItemRotation', true);
+  piling.set('pileItemOffset', () => [Math.random() * 10, Math.random() * 10]);
+  piling.set('pileItemRotation', () => Math.random() * 10);
 
   return [piling];
 };

--- a/examples/photos.js
+++ b/examples/photos.js
@@ -19,7 +19,7 @@ const createPhotoPiles = async element => {
 
   piling.set('pileBorderSize', pile => pile.items.length - 1);
 
-  piling.set('pileItemAlignment', false);
+  piling.set('pileItemOffset', []);
   piling.set('pileItemRotation', true);
 
   return [piling];

--- a/src/library.js
+++ b/src/library.js
@@ -275,8 +275,6 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     previewBorderOpacity: true,
-    randomOffsetRange: true,
-    randomRotationRange: true,
     renderer: {
       get: 'itemRenderer',
       set: value => [createAction.setItemRenderer(value)]

--- a/src/library.js
+++ b/src/library.js
@@ -154,7 +154,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     rowHeight: true,
     cellAspectRatio: true,
     cellPadding: true,
-    pileItemAlignment: true,
+    pileItemOffset: true,
     pileItemBrightness: true,
     pileItemOpacity: true,
     pileItemRotation: true,
@@ -784,10 +784,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
       pileInstances.forEach(pile => {
         if (pile.cover()) {
-          const { pileItemAlignment, pileItemRotation } = store.getState();
+          const { pileItemOffset, pileItemRotation } = store.getState();
 
           pile.positionItems(
-            pileItemAlignment,
+            pileItemOffset,
             pileItemRotation,
             animator,
             store.getState().previewSpacing
@@ -862,7 +862,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const updateItemTexture = (updatedItems = []) => {
     const {
       items,
-      pileItemAlignment,
+      pileItemOffset,
       pileItemRotation,
       previewSpacing
     } = store.getState();
@@ -887,7 +887,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             const pileState = piles[id];
             pile.replaceItemsImage();
             pile.positionItems(
-              pileItemAlignment,
+              pileItemOffset,
               pileItemRotation,
               animator,
               previewSpacing
@@ -908,7 +908,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const {
       items,
       itemRenderer,
-      pileItemAlignment,
+      pileItemOffset,
       pileItemRotation,
       previewSpacing
     } = store.getState();
@@ -948,7 +948,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
             store
           });
           pile.positionItems(
-            pileItemAlignment,
+            pileItemOffset,
             pileItemRotation,
             animator,
             previewSpacing
@@ -1173,12 +1173,12 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const positionPilesDb = debounce(positionPiles, POSITION_PILES_DEBOUNCE_TIME);
 
   const positionItems = pileId => {
-    const { pileItemAlignment, pileItemRotation } = store.getState();
+    const { pileItemOffset, pileItemRotation } = store.getState();
 
     pileInstances
       .get(pileId)
       .positionItems(
-        pileItemAlignment,
+        pileItemOffset,
         pileItemRotation,
         animator,
         store.getState().previewSpacing
@@ -2379,7 +2379,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       stateUpdates.add('layout');
     }
 
-    if (state.pileItemAlignment !== newState.pileItemAlignment) {
+    if (state.pileItemOffset !== newState.pileItemOffset) {
       stateUpdates.add('layout');
     }
 

--- a/src/pile.js
+++ b/src/pile.js
@@ -526,7 +526,7 @@ const createPile = (
         });
       });
     } else {
-      newItems.forEach(pileItem => {
+      newItems.forEach((pileItem, index) => {
         const item = pileItem.item;
         const displayObject = pileItem.displayObject;
 
@@ -551,30 +551,26 @@ const createPile = (
           delete item.tmpAbsX;
           delete item.tmpAbsY;
         }
-      });
 
-      normalItemContainer.children.forEach((item, index) => {
-        const pileState = store.state.piles[id];
-        const itemState = store.state.items[pileState.items[index]];
+        const pileState = store.state.piles[pileItem.id];
+        const itemState = store.state.items[item.id];
+        const itemIndex = pileState.items.indexOf(item.id);
 
         const offset = isFunction(pileItemOffset)
-          ? pileItemOffset(itemState, index, pileState)
-          : pileItemOffset;
+          ? pileItemOffset(itemState, itemIndex, pileState)
+          : pileItemOffset.map(_offset => _offset * itemIndex);
 
         angle = isFunction(pileItemRotation)
-          ? pileItemRotation(itemState, index, pileState)
+          ? pileItemRotation(itemState, itemIndex, pileState)
           : pileItemRotation;
 
-        const offsetX = index * offset[0];
-        const offsetY = index * offset[1];
-
         animatePositionItems(
-          item,
-          offsetX,
-          offsetY,
+          pileItem.displayObject,
+          offset[0],
+          offset[1],
           angle,
           animator,
-          index === normalItemContainer.children.length - 1
+          index === newItems.length - 1
         );
       });
     }

--- a/src/pile.js
+++ b/src/pile.js
@@ -3,6 +3,7 @@ import {
   interpolateNumber,
   interpolateVector,
   isClose,
+  isFunction,
   l2PointDist,
   mergeMaps,
   toVoid
@@ -500,13 +501,18 @@ const createPile = (
   };
 
   const positionItems = (
-    itemAlignment,
+    pileItemOffset,
     itemRotation,
     animator,
     previewSpacing
   ) => {
     isPositioning = true;
     let angle = 0;
+
+    const offset = isFunction(pileItemOffset)
+      ? pileItemOffset(store.getState().piles[id])
+      : pileItemOffset;
+
     if (getCover()) {
       getCover().then(coverImage => {
         const halfSpacing = previewSpacing / 2;
@@ -523,7 +529,7 @@ const createPile = (
           );
         });
       });
-    } else if (itemAlignment || allItems.length === 1) {
+    } else if (offset.length || allItems.length === 1) {
       // image
       newItems.forEach(pileItem => {
         const item = pileItem.item;
@@ -553,38 +559,13 @@ const createPile = (
       });
 
       normalItemContainer.children.forEach((item, index) => {
-        // eslint-disable-next-line no-param-reassign
-        if (!Array.isArray(itemAlignment)) itemAlignment = [itemAlignment];
-        const padding = index * 5;
-        let verticalPadding = 0;
-        let horizontalPadding = 0;
-        itemAlignment.forEach(alignment => {
-          switch (alignment) {
-            case 'top':
-              verticalPadding -= padding;
-              break;
-            case 'left':
-              horizontalPadding -= padding;
-              break;
-            case 'bottom':
-              verticalPadding += padding;
-              break;
-            case 'right':
-              horizontalPadding += padding;
-              break;
-            case 'overlap':
-              break;
-            // bottom-right
-            default:
-              verticalPadding += padding;
-              horizontalPadding += padding;
-          }
-        });
+        const offsetX = index * offset[0];
+        const offsetY = index * offset[1];
 
         animatePositionItems(
           item,
-          horizontalPadding,
-          verticalPadding,
+          offsetX,
+          offsetY,
           angle,
           animator,
           index === normalItemContainer.children.length - 1

--- a/src/store.js
+++ b/src/store.js
@@ -200,10 +200,7 @@ const [pileItemBrightness, setPileItemBrightness] = setter(
   DEFAULT_PILE_ITEM_BRIGHTNESS
 );
 
-const [pileItemRotation, setPileItemRotation] = setter(
-  'pileItemRotation',
-  false
-);
+const [pileItemRotation, setPileItemRotation] = setter('pileItemRotation', 0);
 
 const [pileItemTint, setPileItemTint] = setter(
   'pileItemTint',
@@ -336,16 +333,6 @@ const [pileVisibilityItems, setPileVisibilityItems] = setter(
 const [pileOpacity, setPileOpacity] = setter('pileOpacity', 1.0);
 
 const [pileScale, setPileScale] = setter('pileScale', 1.0);
-
-const [randomOffsetRange, setRandomOffsetRange] = setter('randomOffsetRange', [
-  -30,
-  30
-]);
-
-const [
-  randomRotationRange,
-  setRandomRotationRange
-] = setter('randomRotationRange', [-10, 10]);
 
 // reducer
 const piles = (previousState = [], action) => {
@@ -543,8 +530,6 @@ const createStore = () => {
     previewBorderOpacity,
     previewRenderer,
     previewSpacing,
-    randomOffsetRange,
-    randomRotationRange,
     rowHeight,
     showGrid,
     showSpatialIndex,
@@ -647,8 +632,6 @@ export const createAction = {
   setPreviewBorderOpacity,
   setPreviewRenderer,
   setPreviewSpacing,
-  setRandomOffsetRange,
-  setRandomRotationRange,
   setRowHeight,
   setShowGrid,
   setShowSpatialIndex,

--- a/src/store.js
+++ b/src/store.js
@@ -193,10 +193,7 @@ const [rowHeight, setRowHeight] = setter('rowHeight');
 const [cellAspectRatio, setCellAspectRatio] = setter('cellAspectRatio', 1);
 const [cellPadding, setCellPadding] = setter('cellPadding', 12);
 
-const [pileItemAlignment, setPileItemAlignment] = setter('pileItemAlignment', [
-  'bottom',
-  'right'
-]);
+const [pileItemOffset, setPileItemOffset] = setter('pileItemOffset', [5, 5]);
 
 const [pileItemBrightness, setPileItemBrightness] = setter(
   'pileItemBrightness',
@@ -530,7 +527,7 @@ const createStore = () => {
     pileBorderSize,
     pileCellAlignment,
     pileContextMenuItems,
-    pileItemAlignment,
+    pileItemOffset,
     pileItemBrightness,
     pileItemOpacity,
     pileItemRotation,
@@ -635,7 +632,7 @@ export const createAction = {
   setPileBorderSize,
   setPileCellAlignment,
   setPileContextMenuItems,
-  setPileItemAlignment,
+  setPileItemOffset,
   setPileItemBrightness,
   setPileItemOpacity,
   setPileItemRotation,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Replace `pileItemAlignment` with `pileItemOffset`

> Why is it necessary?

We should allow the user to customize the pile-item offset

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
