### PR TITLE
Split all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Add `splitAll()` to scatter all piles
 - Add `pileBy()` for layout-, location-, and data-driven piling
 - Add `pileItemOrder` to sort the items on a pile by a callback function
 - Add `previewItemOffset` to position the previews as user specified

--- a/DOCS.md
+++ b/DOCS.md
@@ -589,6 +589,10 @@ Render the root PIXI container.
 
 This will the halting popup.
 
+#### `piling.splitAll()`
+
+Scatter all the piles at the same time.
+
 #### `piling.subscribe(eventName, eventHandler)`
 
 Subscribe to an event.

--- a/examples/lines.js
+++ b/examples/lines.js
@@ -50,6 +50,12 @@ const createSvgLinesPiles = element => {
       {
         label: 'Redraw',
         callback: redrawHandler
+      },
+      {
+        label: 'Split All',
+        callback: () => {
+          piling.splitAll();
+        }
       }
     ]
   });

--- a/src/library.js
+++ b/src/library.js
@@ -1775,6 +1775,42 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     }
   };
 
+  const splitAll = () => {
+    const { piles } = store.state;
+
+    const scatteredPiles = [];
+    const movingPiles = [];
+
+    Object.entries(piles).forEach(([id, pile]) => {
+      const items = [...pile.items];
+      if (items.length > 1) {
+        scatteredPiles.push({
+          items,
+          x: pile.x,
+          y: pile.y
+        });
+      } else if (items.length === 1) {
+        const pos = renderedItems.get(items[0]).originalPosition;
+        movingPiles.push({
+          id,
+          x: pos[0],
+          y: pos[1]
+        });
+      }
+    });
+
+    store.dispatch(
+      batchActions([
+        createAction.scatterPiles(scatteredPiles),
+        createAction.movePiles(movingPiles)
+      ])
+    );
+
+    scatteredPiles.forEach(pile => {
+      animateDepile(pile.items[0], pile.items);
+    });
+  };
+
   const animateTempDepileItems = (item, x, y, { onDone = identity } = {}) => {
     const tweener = createTweener({
       interpolator: interpolateVector,
@@ -4050,6 +4086,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     renderer,
     resume,
     set: setPublic,
+    splitAll,
     subscribe: pubSub.subscribe,
     unsubscribe: pubSub.unsubscribe
   };


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add `splitAll()` to scatter all the piles.

![Mar-14-2020 15-45-05](https://user-images.githubusercontent.com/39853191/76677574-d35cc580-660a-11ea-8178-3038b8b8da0d.gif)

> Why is it necessary?

Fixes #139 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [x] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
