### PR TITLE
Pile background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Next
 
+- Add the following properties to give more control to the pile background color: (#151)
+  - `pileBackgroundColorActive`
+  - `pileBackgroundColorFocus`
+  - `pileBackgroundColorHover`
+  - `pileBackgroundOpacityActive`
+  - `pileBackgroundOpacityFocus`
+  - `pileBackgroundOpacityHover`
 - Add `cellSize` to define the size of the cell (#136)
 - Add `splitAll()` to scatter all piles (#144)
 - Add `pileBy()` for layout-, location-, and data-driven piling (#129)

--- a/DOCS.md
+++ b/DOCS.md
@@ -189,8 +189,14 @@ The list of all understood properties is given below.
 | orderer                    | function                | row-major    | see [`notes`](#notes)                                                                           | `true`     |
 | magnifiedPiles             | array                   | `[]`         | the id of current magnified pile                                                                | `true`     |
 | navigationMode             | string                  | auto         | Can be one of auto, panZoom, or scroll                                                          | `false`    |
-| pileBackgroundColor        | string or int           | `0x000000`   | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
-| pileBackgroundOpacity      | float                   | `1.0`        | must be in [`0`,`1`]                                                                            | `false`    |
+| pileBackgroundColor        | string or int           |              | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
+| pileBackgroundOpacity      | float                   | `0`          | must be in [`0`,`1`]                                                                            | `false`    |
+| pileBackgroundColorHover   | string or int           |              | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
+| pileBackgroundOpacityHover | float                   | `0.85`       | must be in [`0`,`1`]                                                                            | `false`    |
+| pileBackgroundColorFocus   | string or int           |              | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
+| pileBackgroundOpacityFocus | float                   |              | must be in [`0`,`1`]                                                                            | `false`    |
+| pileBackgroundColorActive  | string or int           |              | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
+| pileBackgroundOpacityActive| float                   |              | must be in [`0`,`1`]                                                                            | `false`    |
 | pileBorderColor            | string or int           | `0x808080`   | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
 | pileBorderOpacity          | float                   | `1.0`        | must be in [`0`,`1`]                                                                            | `false`    |
 | pileBorderColorHover       | string or int           | `0x808080`   | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `false`    |
@@ -300,6 +306,12 @@ The list of all understood properties is given below.
   piling.set('lassoFillColor', 'rgb(255, 0, 0)');
   piling.set('lassoFillOpacity', 0.66);
   ```
+
+- If `pileBackgroundColor` is not defined, it will be set to the same color as the background depending on `darkMode`. 
+
+  `pileBackgroundColorActive`, `pileBackgroundColorFocus`, and `pileBackgroundColorHover` will inherit from `pileBackgroundColor` if not defined.
+  
+  `pileBackgroundOpacityFocus` and `pileBackgroundOpacityActive` will inherit from `pileBackgroundOpacityHover` if not defined.
 
 - `pileContextMenuItems` is an array of objects, which must have a `label` and `callback` property. Optionally, an object can also specify an `id`, which will be assigned to the corresponding button in the context menu, and `keepOpen: true` to not close the context menu after clicking on the corresponding button. The `callback` function is triggered whenever the user clicks on the corresponding button and it receives the pile definition, which contains the pile id, the ids of the items on the pile, and the pile's x and y coordinate.
 

--- a/examples/drawings.js
+++ b/examples/drawings.js
@@ -65,8 +65,8 @@ const createDrawingPiles = async (element, darkMode) => {
     pileItemInvert: darkMode,
     pileItemOffset: [0, 0],
     pileBackgroundColor: darkMode
-      ? 'rgba(0, 0, 0, 0.85)'
-      : 'rgba(255, 255, 255, 0.85)',
+      ? 'rgba(0, 0, 0, 0.9)'
+      : 'rgba(255, 255, 255, 0.9)',
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 2),
     pileVisibilityItems: pile => pile.items.length === 1,
     backgroundColor: '#ffffff',

--- a/examples/joy-plot.js
+++ b/examples/joy-plot.js
@@ -133,9 +133,6 @@ const createSvgLinesPiles = async (element, darkMode) => {
     pileItemOffset: [0, 8],
     pileItemBrightness: (_, i, pile) =>
       Math.min(0.5, 0.01 * (pile.items.length - i - 1)),
-    pileBackgroundColor: darkMode
-      ? 'rgba(0,0,0,0.85)'
-      : 'rgba(255,255,255,0.85)',
     pileScale: pile => 1 + Math.min(0.5, (pile.items.length - 1) * 0.1)
   });
 

--- a/examples/lines.js
+++ b/examples/lines.js
@@ -47,9 +47,6 @@ const createSvgLinesPiles = (element, darkMode) => {
     pileItemOpacity: (item, i, pile) =>
       (1 / pile.items.length) * (2 / 3) + 1 / 3,
     pileItemOffset: [0, 0],
-    pileBackgroundColor: darkMode
-      ? 'rgba(0, 0, 0, 0.85)'
-      : 'rgba(255, 255, 255, 0.85)',
     pileContextMenuItems: [
       {
         label: 'Redraw',

--- a/src/library.js
+++ b/src/library.js
@@ -290,6 +290,45 @@ const createPilingJs = (rootElement, initOptions = {}) => {
       }
     },
     pileBackgroundOpacity: true,
+    pileBackgroundColorHover: {
+      set: value => {
+        if (isFunction(value))
+          return [createAction.setPileBackgroundColor(value)];
+
+        const [color, opacity] = colorToDecAlpha(value, null);
+        const actions = [createAction.setPileBackgroundColorHover(color)];
+        if (opacity !== null)
+          actions.push(createAction.setPileBackgroundOpacityHover(opacity));
+        return actions;
+      }
+    },
+    pileBackgroundOpacityHover: true,
+    pileBackgroundColorFocus: {
+      set: value => {
+        if (isFunction(value))
+          return [createAction.setPileBackgroundColor(value)];
+
+        const [color, opacity] = colorToDecAlpha(value, null);
+        const actions = [createAction.setPileBackgroundColorFocus(color)];
+        if (opacity !== null)
+          actions.push(createAction.setPileBackgroundOpacityFocus(opacity));
+        return actions;
+      }
+    },
+    pileBackgroundOpacityFocus: true,
+    pileBackgroundColorActive: {
+      set: value => {
+        if (isFunction(value))
+          return [createAction.setPileBackgroundColor(value)];
+
+        const [color, opacity] = colorToDecAlpha(value, null);
+        const actions = [createAction.setPileBackgroundColorActive(color)];
+        if (opacity !== null)
+          actions.push(createAction.setPileBackgroundOpacityActive(opacity));
+        return actions;
+      }
+    },
+    pileBackgroundOpacityActive: true,
     pileCellAlignment: true,
     pileContextMenuItems: true,
     pileOpacity: true,

--- a/src/library.js
+++ b/src/library.js
@@ -143,6 +143,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   root.addChild(mask);
   stage.mask = mask;
 
+  const createColorOpacityActions = (colorAction, opacityAction) => value => {
+    if (isFunction(value)) return [createAction[colorAction](value)];
+
+    const [color, opacity] = colorToDecAlpha(value, null);
+    const actions = [createAction[colorAction](color)];
+    if (opacity !== null) actions.push(createAction[opacityAction](opacity));
+
+    return actions;
+  };
+
   const properties = {
     arrangementObjective: true,
     arrangementOnPile: true,
@@ -162,13 +172,7 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     easing: true,
     focusedPiles: true,
     gridColor: {
-      set: value => {
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setGridColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setGridOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions('setGridColor', 'setGridOpacity')
     },
     gridOpacity: true,
     items: {
@@ -181,25 +185,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     itemSize: true,
     itemSizeRange: true,
     lassoFillColor: {
-      set: value => {
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setLassoFillColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setLassoFillOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions('setLassoFillColor', 'setLassoFillOpacity')
     },
     lassoFillOpacity: true,
     lassoShowStartIndicator: true,
     lassoStartIndicatorOpacity: true,
     lassoStrokeColor: {
-      set: value => {
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setLassoStrokeColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setLassoStrokeOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setLassoStrokeColor',
+        'setLassoStrokeOpacity'
+      )
     },
     lassoStrokeOpacity: true,
     lassoStrokeSize: true,
@@ -245,104 +240,60 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     pileLabelStackAlign: true,
     pileLabelText: true,
     pileBorderColor: {
-      set: value => {
-        if (isFunction(value)) return [createAction.setPileBorderColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBorderColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBorderOpacity(opacity));
-
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBorderColor',
+        'setPileBorderOpacity'
+      )
     },
     pileBorderOpacity: true,
     pileBorderColorHover: {
-      set: value => {
-        if (isFunction(value)) return [createAction.setPileBorderColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBorderColorHover(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBorderOpacityHover(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBorderColorHover',
+        'setPileBorderOpacityHover'
+      )
     },
     pileBorderOpacityHover: true,
     pileBorderColorFocus: {
-      set: value => {
-        if (isFunction(value)) return [createAction.setPileBorderColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBorderColorFocus(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBorderOpacityFocus(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBorderColorFocus',
+        'setPileBorderOpacityFocus'
+      )
     },
     pileBorderOpacityFocus: true,
     pileBorderColorActive: {
-      set: value => {
-        if (isFunction(value)) return [createAction.setPileBorderColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBorderColorActive(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBorderOpacityActive(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBorderColorActive',
+        'setPileBorderOpacityActive'
+      )
     },
     pileBorderOpacityActive: true,
     pileBorderSize: true,
     pileBackgroundColor: {
-      set: value => {
-        if (isFunction(value)) return [createAction.setPileBorderColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBackgroundColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBackgroundOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBackgroundColor',
+        'setPileBackgroundOpacity'
+      )
     },
     pileBackgroundOpacity: true,
     pileBackgroundColorHover: {
-      set: value => {
-        if (isFunction(value))
-          return [createAction.setPileBackgroundColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBackgroundColorHover(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBackgroundOpacityHover(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBackgroundColorHover',
+        'setPileBackgroundOpacityHover'
+      )
     },
     pileBackgroundOpacityHover: true,
     pileBackgroundColorFocus: {
-      set: value => {
-        if (isFunction(value))
-          return [createAction.setPileBackgroundColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBackgroundColorFocus(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBackgroundOpacityFocus(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBackgroundColorFocus',
+        'setPileBackgroundOpacityFocus'
+      )
     },
     pileBackgroundOpacityFocus: true,
     pileBackgroundColorActive: {
-      set: value => {
-        if (isFunction(value))
-          return [createAction.setPileBackgroundColor(value)];
-
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPileBackgroundColorActive(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPileBackgroundOpacityActive(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPileBackgroundColorActive',
+        'setPileBackgroundOpacityActive'
+      )
     },
     pileBackgroundOpacityActive: true,
     pileCellAlignment: true,
@@ -353,23 +304,17 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     popupBackgroundOpacity: true,
     previewAggregator: true,
     previewBackgroundColor: {
-      set: value => {
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPreviewBackgroundColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPreviewBackgroundOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPreviewBackgroundColor',
+        'setPreviewBackgroundOpacity'
+      )
     },
     previewBackgroundOpacity: true,
     previewBorderColor: {
-      set: value => {
-        const [color, opacity] = colorToDecAlpha(value, null);
-        const actions = [createAction.setPreviewBorderColor(color)];
-        if (opacity !== null)
-          actions.push(createAction.setPreviewBorderOpacity(opacity));
-        return actions;
-      }
+      set: createColorOpacityActions(
+        'setPreviewBorderColor',
+        'setPreviewBorderOpacity'
+      )
     },
     previewBorderOpacity: true,
     previewItemOffset: true,

--- a/src/pile.js
+++ b/src/pile.js
@@ -197,10 +197,21 @@ const createPile = (
     }
   };
 
+  const getBackgroundOpacity = () => {
+    let backgroundOpacity =
+      store.state[`pileBackgroundOpacity${modeToString.get(mode) || ''}`];
+
+    if (backgroundOpacity === null)
+      backgroundOpacity = store.state.pileBackgroundOpacityHover;
+
+    return backgroundOpacity;
+  };
+
   const drawBorder = () => {
     const size = getBorderSize();
+    const backgroundOpacity = getBackgroundOpacity();
 
-    if (!size) {
+    if (!size && !backgroundOpacity) {
       borderGraphics.clear();
       return;
     }
@@ -223,10 +234,12 @@ const createPile = (
     const x = contentBounds.x - borderBounds.x;
     const y = contentBounds.y - borderBounds.y;
     const borderOffset = Math.ceil(size / 2);
-    const pileBackgroundColor = getBackgroundColor();
+    const backgroundColor =
+      state[`pileBackgroundColor${modeToString.get(mode) || ''}`] ||
+      getBackgroundColor();
 
     // draw black background
-    borderGraphics.beginFill(pileBackgroundColor, state.pileBackgroundOpacity);
+    borderGraphics.beginFill(backgroundColor, backgroundOpacity);
     borderGraphics.drawRect(
       x - borderOffset,
       y - borderOffset,

--- a/src/store.js
+++ b/src/store.js
@@ -278,56 +278,67 @@ const [previewBorderOpacity, setPreviewBorderOpacity] = setter(
   0.85
 );
 
+const [pileBackgroundColor, setPileBackgroundColor] = setter(
+  'pileBackgroundColor'
+);
+const [pileBackgroundOpacity, setPileBackgroundOpacity] = setter(
+  'pileBackgroundOpacity',
+  0
+);
+const [pileBackgroundColorHover, setPileBackgroundColorHover] = setter(
+  'pileBackgroundColorHover'
+);
+const [pileBackgroundOpacityHover, setPileBackgroundOpacityHover] = setter(
+  'pileBackgroundOpacityHover',
+  0.85
+);
+const [pileBackgroundColorFocus, setPileBackgroundColorFocus] = setter(
+  'pileBackgroundColorFocus'
+);
+const [pileBackgroundOpacityFocus, setPileBackgroundOpacityFocus] = setter(
+  'pileBackgroundOpacityFocus'
+);
+const [pileBackgroundColorActive, setPileBackgroundColorActive] = setter(
+  'pileBackgroundColorActive'
+);
+const [pileBackgroundOpacityActive, setPileBackgroundOpacityActive] = setter(
+  'pileBackgroundOpacityActive'
+);
+
 const [pileBorderColor, setPileBorderColor] = setter(
   'pileBorderColor',
   0x808080
 );
-
 const [pileBorderOpacity, setPileBorderOpacity] = setter(
   'pileBorderOpacity',
   1.0
 );
-
 const [pileBorderColorHover, setPileBorderColorHover] = setter(
   'pileBorderColorHover',
   0x808080
 );
-
 const [pileBorderOpacityHover, setPileBorderOpacityHover] = setter(
   'pileBorderOpacityHover',
   1.0
 );
-
 const [pileBorderColorFocus, setPileBorderColorFocus] = setter(
   'pileBorderColorFocus',
   0xeee462
 );
-
 const [pileBorderOpacityFocus, setPileBorderOpacityFocus] = setter(
   'pileBorderOpacityFocus',
   1.0
 );
-
 const [pileBorderColorActive, setPileBorderColorActive] = setter(
   'pileBorderColorActive',
   0xffa5da
 );
-
 const [pileBorderOpacityActive, setPileBorderOpacityActive] = setter(
   'pileBorderOpacityActive',
   1.0
 );
 
 const [pileBorderSize, setPileBorderSize] = setter('pileBorderSize', 0);
-
-const [pileBackgroundColor, setPileBackgroundColor] = setter(
-  'pileBackgroundColor'
-);
-
-const [pileBackgroundOpacity, setPileBackgroundOpacity] = setter(
-  'pileBackgroundOpacity',
-  0.85
-);
 
 // 'topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'center'
 const [pileCellAlignment, setPileCellAlignment] = setter(
@@ -561,7 +572,13 @@ const createStore = () => {
     navigationMode,
     orderer,
     pileBackgroundColor,
+    pileBackgroundColorActive,
+    pileBackgroundColorFocus,
+    pileBackgroundColorHover,
     pileBackgroundOpacity,
+    pileBackgroundOpacityActive,
+    pileBackgroundOpacityFocus,
+    pileBackgroundOpacityHover,
     pileBorderColor,
     pileBorderColorActive,
     pileBorderColorFocus,
@@ -706,7 +723,13 @@ export const createAction = {
   setNavigationMode,
   setOrderer,
   setPileBackgroundColor,
+  setPileBackgroundColorActive,
+  setPileBackgroundColorFocus,
+  setPileBackgroundColorHover,
   setPileBackgroundOpacity,
+  setPileBackgroundOpacityActive,
+  setPileBackgroundOpacityFocus,
+  setPileBackgroundOpacityHover,
   setPileBorderColor,
   setPileBorderColorActive,
   setPileBorderColorFocus,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add the following properties
  - `pileBackgroundColorActive`
  - `pileBackgroundColorFocus`
  - `pileBackgroundColorHover`
  - `pileBackgroundOpacityActive`
  - `pileBackgroundOpacityFocus`
  - `pileBackgroundOpacityHover`

> Why is it necessary?

Fixes #150 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
