### PR TITLE
Pile label size aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Add `pileLabelSizeAggregator` for visualizing the distribution of categories
 - Add some pile/item properties and label properties to sidebar
 - Add the following properties to give more control to the pile background color: (#151)
   - `pileBackgroundColorActive`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Next
 
-- Add `pileLabelSizeAggregator` for visualizing the distribution of categories
+- Add `pileLabelSizeTransform` property for adjusting the relative size of pile labels. When set to `histogram`, this option can be used to visualizing the distribution of categories on a pile
 - Add some pile/item properties and label properties to sidebar
 - Add the following properties to give more control to the pile background color: (#151)
   - `pileBackgroundColorActive`

--- a/docs/README.md
+++ b/docs/README.md
@@ -455,9 +455,9 @@ Unsubscribe from an event. See [events](#events) for all the events.
 | pileLabelAlign              | String                            | `bottom`           | `bottom` or `top`                                                                               | `true`     |
 | pileLabelColor              | array or function                 |                    | see [`notes`](#notes)                                                                           | `true`     |
 | pileLabelFontSize           | int                               | 8                  |                                                                                                 | `true`     |
-| pileLabelHeight             | float                             | 8                  |                                                                                                 | `true`     |
-| pileLabelStackAlign         | String                            | `horizontal`       | `horizontal` or `vertical`                                                                      | `true`     |
-| pileLabelSizeAggregator     | `histogram` or function           |                |  see [`notes`](#notes)                                                                           | `true`     |
+| pileLabelHeight             | float or function                 | 2                  |                                                                                                 | `true`     |
+| pileLabelStackAlign         | string                            | `horizontal`       | `horizontal` or `vertical`                                                                      | `true`     |
+| pileLabelSizeAggregator     | string or function                | `histogram`        | see [`notes`](#notes)                                                                           | `true`     |
 | pileLabelText               | array or function                 | `false`            | see [`notes`](#notes)                                                                           | `true`     |
 | pileOpacity                 | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
 | pileScale                   | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |

--- a/docs/README.md
+++ b/docs/README.md
@@ -689,8 +689,10 @@ Unsubscribe from an event. See [events](#events) for all the events.
   // The following 2 examples are equivalent
   piling.set('pileLabelSizeAggregator', 'histogram');
   piling.set('pileLabelSizeAggregator', histogram => {
-    const maxValue = Math.max(...histogram);
-    return histogram.map(x => x / maxValue);
+    // Histogram is a label-count dictionary
+    const counts = Object.values(histogram);
+    const maxCount = Math.max(...counts);
+    return counts.map(x => x / maxCount);
   });
   ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -457,6 +457,7 @@ Unsubscribe from an event. See [events](#events) for all the events.
 | pileLabelFontSize           | int                               | 8                  |                                                                                                 | `true`     |
 | pileLabelHeight             | float                             | 8                  |                                                                                                 | `true`     |
 | pileLabelStackAlign         | String                            | `horizontal`       | `horizontal` or `vertical`                                                                      | `true`     |
+| pileLabelSizeAggregator     | `histogram` or function           |                |  see [`notes`](#notes)                                                                           | `true`     |
 | pileLabelText               | array or function                 | `false`            | see [`notes`](#notes)                                                                           | `true`     |
 | pileOpacity                 | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
 | pileScale                   | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
@@ -680,6 +681,26 @@ Unsubscribe from an event. See [events](#events) for all the events.
       // Pick the color for the `label`
       return color;
     }
+  ```
+
+- `pileLabelSizeAggregator` is used to get a relative distribution of categories across a pile. It can be set to `'histogram'` or a callback function. E.g.,
+
+  ```javascript
+  // The following 2 examples are equivalent
+  piling.set('pileLabelSizeAggregator', 'histogram');
+  piling.set('pileLabelSizeAggregator', histogram => {
+    const maxValue = Math.max(...histogram);
+    return histogram.map(x => x / maxValue);
+  });
+  ```
+
+  The callback function should receive an array of the sum of each label and return an array of scale factors that ranges in `[0, 1]`. The signature is as follows:
+
+  ```javascript
+    function (histogram) => {
+      // Do stuff
+      return arrayofScaleFactors;
+    };
   ```
 
 - `pileLabelText` can be set to a boolean, an `array` of strings, or a callback function. E.g.,

--- a/docs/README.md
+++ b/docs/README.md
@@ -457,7 +457,7 @@ Unsubscribe from an event. See [events](#events) for all the events.
 | pileLabelFontSize           | int                               | 8                  |                                                                                                 | `true`     |
 | pileLabelHeight             | float or function                 | 2                  |                                                                                                 | `true`     |
 | pileLabelStackAlign         | string                            | `horizontal`       | `horizontal` or `vertical`                                                                      | `true`     |
-| pileLabelSizeAggregator     | string or function                | `histogram`        | see [`notes`](#notes)                                                                           | `true`     |
+| pileLabelSizeTransform      | string or function                | `histogram`        | see [`notes`](#notes)                                                                           | `true`     |
 | pileLabelText               | array or function                 | `false`            | see [`notes`](#notes)                                                                           | `true`     |
 | pileOpacity                 | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
 | pileScale                   | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
@@ -683,14 +683,13 @@ Unsubscribe from an event. See [events](#events) for all the events.
     }
   ```
 
-- `pileLabelSizeAggregator` is used to get a relative distribution of categories across a pile. It can be set to `'histogram'` or a callback function. E.g.,
+- `pileLabelSizeTransform` is used to get a relative distribution of categories across a pile. It can be set to `'histogram'` or a callback function. E.g.,
 
   ```javascript
   // The following 2 examples are equivalent
-  piling.set('pileLabelSizeAggregator', 'histogram');
-  piling.set('pileLabelSizeAggregator', histogram => {
-    // Histogram is a label-count dictionary
-    const counts = Object.values(histogram);
+  piling.set('pileLabelSizeTransform', 'histogram');
+  piling.set('pileLabelSizeTransform', (counts, labels) => {
+    // This function normalizes the counts to be in [0,1]
     const maxCount = Math.max(...counts);
     return counts.map(x => x / maxCount);
   });

--- a/examples/drawings.js
+++ b/examples/drawings.js
@@ -88,17 +88,16 @@ const createDrawingPiles = async (element, darkMode) => {
     pileLabelColor: regionToColor,
     pileLabelStackAlign: 'horizontal',
     pileLabelHeight: pile => (pile.items.length > 1 ? 12 : 2),
-    pileLabelSizeAggregator: histogram => {
-      const values = Object.values(histogram);
-      const sumValue = sum(values);
-      let maxValue = 0;
-      const normValues = Object.entries(histogram).map(([region, value]) => {
+    pileLabelSizeTransform: (counts, labels) => {
+      const totalCounts = sum(counts);
+      let max = 0;
+      const normValues = counts.map((c, i) => {
         const observedOverExpected =
-          value / (sumValue * (regionHistogram[region] || 1));
-        maxValue = Math.max(maxValue, observedOverExpected);
+          c / (totalCounts * (regionHistogram[labels[i]] || 1));
+        max = Math.max(max, observedOverExpected);
         return observedOverExpected;
       });
-      return normValues.map(x => x / maxValue);
+      return normValues.map(x => x / max);
     }
   });
 

--- a/examples/drawings.js
+++ b/examples/drawings.js
@@ -74,7 +74,8 @@ const createDrawingPiles = async (element, darkMode) => {
     lassoStrokeColor: '#000000',
     pileLabel: 'region',
     pileLabelColor: regionToColor,
-    pileLabelStackAlign: 'vertical'
+    pileLabelStackAlign: 'vertical',
+    pileLabelSizeAggregator: 'histogram'
   });
 
   piling.subscribe('itemUpdate', () => {

--- a/examples/index.js
+++ b/examples/index.js
@@ -771,7 +771,9 @@ createPiles(exampleEl.value).then(([pilingLib, additionalOptions = []]) => {
         },
         {
           name: 'pileLabelHeight',
-          hide: categoricalProps.length === 0,
+          hide:
+            categoricalProps.length === 0 ||
+            isFunction(piling.get('pileLabelHeight')),
           labelMinWidth: '6rem',
           dtype: 'int',
           min: 0.1,

--- a/src/library.js
+++ b/src/library.js
@@ -245,10 +245,10 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     pileLabelFontSize: true,
     pileLabelHeight: true,
     pileLabelStackAlign: true,
-    pileLabelSizeAggregator: {
+    pileLabelSizeTransform: {
       set: value => {
         const aggregator = expandLabelSizeAggregator(value);
-        const actions = [createAction.setPileLabelSizeAggregator(aggregator)];
+        const actions = [createAction.setPileLabelSizeTransform(aggregator)];
         return actions;
       }
     },
@@ -2991,22 +2991,25 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   };
 
   const getPileLabelSizeScale = (labels, allLabels) => {
-    const { pileLabelSizeAggregator } = store.state;
+    const { pileLabelSizeTransform } = store.state;
 
     const histogram = labels.reduce((hist, label) => {
-      // If `pileLabelSizeAggregator` is falsy this will turn to `1` and
+      // If `pileLabelSizeTransform` is falsy this will turn to `1` and
       // otherwise to `0`
-      hist[label] = +!pileLabelSizeAggregator;
+      hist[label] = +!pileLabelSizeTransform;
       return hist;
     }, {});
 
-    if (!pileLabelSizeAggregator) return histogram;
+    if (!pileLabelSizeTransform) return histogram;
 
     allLabels.forEach(label => {
       histogram[label]++;
     });
 
-    return pileLabelSizeAggregator(histogram);
+    return pileLabelSizeTransform(
+      Object.values(histogram),
+      Object.keys(histogram)
+    );
   };
 
   const setPileLabel = (pileState, pileId, reset = false) => {

--- a/src/library.js
+++ b/src/library.js
@@ -2993,18 +2993,18 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const getPileLabelSizeScale = (labels, allLabels) => {
     const { pileLabelSizeAggregator } = store.state;
 
-    if (!pileLabelSizeAggregator) return new Array(labels.length).fill(1);
-
-    const histogramObj = labels.reduce((obj, label) => {
-      obj[label] = 0;
-      return obj;
+    const histogram = labels.reduce((hist, label) => {
+      // If `pileLabelSizeAggregator` is falsy this will turn to `1` and
+      // otherwise to `0`
+      hist[label] = +!pileLabelSizeAggregator;
+      return hist;
     }, {});
 
-    allLabels.forEach(label => {
-      histogramObj[label]++;
-    });
+    if (!pileLabelSizeAggregator) return histogram;
 
-    const histogram = Object.values(histogramObj);
+    allLabels.forEach(label => {
+      histogram[label]++;
+    });
 
     return pileLabelSizeAggregator(histogram);
   };
@@ -3029,7 +3029,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     const labels = unique(allLabels);
 
-    const scaleFactors = getPileLabelSizeScale(labels, allLabels);
+    const scaleFactors =
+      labels.length > 1 ? getPileLabelSizeScale(labels, allLabels) : [1];
 
     const args = labels.reduce(
       (_args, labelText) => {
@@ -3687,8 +3688,9 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     switch (labelSizeAggregator) {
       case 'histogram':
         return histogram => {
-          const maxValue = Math.max(...histogram);
-          return histogram.map(x => x / maxValue);
+          const values = Object.values(histogram);
+          const maxValue = max(values);
+          return values.map(x => x / maxValue);
         };
 
       default:

--- a/src/pile.js
+++ b/src/pile.js
@@ -1268,15 +1268,20 @@ const createPile = (
       pileLabelAlign,
       pileLabelFontSize,
       pileLabelStackAlign,
-      pileLabelText
+      pileLabelText,
+      piles
     } = store.state;
 
     const bounds = getContentBounds();
 
+    const height = isFunction(pileLabelHeight)
+      ? pileLabelHeight(piles[id])
+      : pileLabelHeight;
+
     let labelWidth = bounds.width / labels.length;
     const labelHeightMax = labelTextures.length
-      ? Math.max(pileLabelText * (pileLabelFontSize + 1), pileLabelHeight)
-      : pileLabelHeight;
+      ? Math.max(pileLabelText * (pileLabelFontSize + 1), height)
+      : height;
 
     const y =
       pileLabelAlign === 'top'

--- a/src/pile.js
+++ b/src/pile.js
@@ -1228,11 +1228,13 @@ const createPile = (
   let pileLabels = [];
   let labelColors = [];
   let labelTextures = [];
+  let labelScaleFactors = [];
 
   const drawLabel = (
     labels = pileLabels,
     colors = labelColors,
-    textures = labelTextures
+    textures = labelTextures,
+    scaleFactors = labelScaleFactors
   ) => {
     if (!labels.length) {
       if (labelGraphics) {
@@ -1249,6 +1251,7 @@ const createPile = (
     pileLabels = labels;
     labelColors = colors;
     labelTextures = textures;
+    labelScaleFactors = scaleFactors;
 
     if (isPositioning || isScaling) return;
 
@@ -1271,13 +1274,13 @@ const createPile = (
     const bounds = getContentBounds();
 
     let labelWidth = bounds.width / labels.length;
-    const labelHeight = labelTextures.length
+    const labelHeightMax = labelTextures.length
       ? Math.max(pileLabelText * (pileLabelFontSize + 1), pileLabelHeight)
       : pileLabelHeight;
 
     const y =
       pileLabelAlign === 'top'
-        ? bounds.y - labelHeight
+        ? bounds.y - labelHeightMax
         : bounds.y + bounds.height;
 
     const toTop = 1 + (y < 0) * -2;
@@ -1285,9 +1288,10 @@ const createPile = (
     labels.forEach((label, index) => {
       let labelX;
       let labelY = y + toTop;
+      let labelHeight = labelHeightMax;
       switch (pileLabelStackAlign) {
         case 'vertical':
-          labelWidth = bounds.width;
+          labelWidth = bounds.width * scaleFactors[index];
           labelX = -bounds.width / 2;
           labelY += (labelHeight + 1) * index * toTop;
           break;
@@ -1295,6 +1299,8 @@ const createPile = (
         case 'horizontal':
         default:
           labelX = labelWidth * index - bounds.width / 2;
+          labelHeight = labelHeightMax * scaleFactors[index];
+          if (pileLabelAlign === 'top') labelY += labelHeightMax - labelHeight;
           break;
       }
       const color = colors[index];
@@ -1312,7 +1318,7 @@ const createPile = (
           case 'vertical':
             textWidth = bounds.width;
             textX = -bounds.width / 2 + textWidth / 2;
-            textY += (labelHeight + 1) * index * toTop;
+            textY += (labelHeightMax + 1) * index * toTop;
             break;
 
           case 'horizontal':

--- a/src/store.js
+++ b/src/store.js
@@ -390,8 +390,8 @@ const [pileLabelFontSize, setPileLabelFontSize] = setter(
   7
 );
 const [pileLabelHeight, setPileLabelHeight] = setter('pileLabelHeight', 2);
-const [pileLabelSizeAggregator, setPileLabelSizeAggregator] = setter(
-  'pileLabelSizeAggregator'
+const [pileLabelSizeTransform, setPileLabelSizeTransform] = setter(
+  'pileLabelSizeTransform'
 );
 
 const items = (previousState = {}, action) => {
@@ -643,7 +643,7 @@ const createStore = () => {
     pileLabelFontSize,
     pileLabelHeight,
     pileLabelStackAlign,
-    pileLabelSizeAggregator,
+    pileLabelSizeTransform,
     pileLabelText,
     pileOpacity,
     piles,
@@ -808,7 +808,7 @@ export const createAction = {
   setPileLabelFontSize,
   setPileLabelHeight,
   setPileLabelStackAlign,
-  setPileLabelSizeAggregator,
+  setPileLabelSizeTransform,
   setPileLabelText,
   setPileVisibilityItems,
   setPileOpacity,

--- a/src/store.js
+++ b/src/store.js
@@ -390,6 +390,9 @@ const [pileLabelFontSize, setPileLabelFontSize] = setter(
   7
 );
 const [pileLabelHeight, setPileLabelHeight] = setter('pileLabelHeight', 2);
+const [pileLabelSizeAggregator, setPileLabelSizeAggregator] = setter(
+  'pileLabelSizeAggregator'
+);
 
 const items = (previousState = {}, action) => {
   switch (action.type) {
@@ -640,6 +643,7 @@ const createStore = () => {
     pileLabelFontSize,
     pileLabelHeight,
     pileLabelStackAlign,
+    pileLabelSizeAggregator,
     pileLabelText,
     pileOpacity,
     piles,
@@ -804,6 +808,7 @@ export const createAction = {
   setPileLabelFontSize,
   setPileLabelHeight,
   setPileLabelStackAlign,
+  setPileLabelSizeAggregator,
   setPileLabelText,
   setPileVisibilityItems,
   setPileOpacity,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Add `pileLabelSizeAggregator` to create barchart-like labels

![Mar-26-2020 14-28-10](https://user-images.githubusercontent.com/39853191/77617166-66ccb980-6f6e-11ea-8db4-99f0453fa6bc.gif)

> Why is it necessary?

Fixes #166 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [x] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
