### PR TITLE
PileOrderItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+- Rename `pileItemOrder` to `pileOrderItems` to make it a pile property (#194)
 - Add piling by selection (i.e., focused piles). See (interactions)[https://piling.js.org/docs/#/README?id=multi-select-grouping] for details.
 - Add `pileLabelSizeTransform` property for adjusting the relative size of pile labels. When set to `histogram`, this option can be used to visualizing the distribution of categories on a pile (#167)
 - Add some pile/item properties and label properties to sidebar (#158)

--- a/DOCS.md
+++ b/DOCS.md
@@ -448,7 +448,6 @@ Unsubscribe from an event. See [events](#events) for all the events.
 | pileItemInvert              | boolean or function               | `false`            | can only be `true` or `false` where `true` refers inverted colors and `false` are normal colors | `false`    |
 | pileItemOffset              | array or function                 | `[5, 5]`           | see [`notes`](#notes)                                                                           | `true`     |
 | pileItemOpacity             | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
-| pileItemOrder               | function                          |                    | see [`notes`](#notes)                                                                           | `true`     |
 | pileItemRotation            | float or function                 | `0`                | see [`notes`](#notes)                                                                           | `true`     |
 | pileItemTint                | string, int or function           | `0xffffff`         | can be HEX, RGB, or RGBA string or hexadecimal value                                            | `true`     |
 | pileLabel                   | string, array, function or object |                    | see [`notes`](#notes)                                                                           | `true`     |
@@ -460,6 +459,7 @@ Unsubscribe from an event. See [events](#events) for all the events.
 | pileLabelSizeTransform      | string or function                | `histogram`        | see [`notes`](#notes)                                                                           | `true`     |
 | pileLabelText               | array or function                 | `false`            | see [`notes`](#notes)                                                                           | `true`     |
 | pileOpacity                 | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
+| pileOrderItems              | function                          |                    | see [`notes`](#notes)                                                                           | `true`     |
 | pileScale                   | float or function                 | `1.0`              | see [`notes`](#notes)                                                                           | `true`     |
 | pileSizeBadge               | boolean or function               | `false`            | if `true` show the pile size as a badge                                                         | `true`     |
 | pileSizeBadgeAlign          | array or function                 | `['top', 'right']` | if `true` show the pile size as a badge                                                         | `true`     |
@@ -594,6 +594,33 @@ Unsubscribe from an event. See [events](#events) for all the events.
   }
   ```
 
+- `pileOrderItems` is used to sort the items on a pile before positioning the items. It should be set to a callback function which will receive the current [pile](#statepiles), and should return a `Map` that maps the item's id to its expected index after sorting. E.g.,
+
+  ```javascript
+  const pileOrderItems = pileState => {
+    const itemIds = pileState.items;
+    itemIds.sort((a, b) => a - b);
+
+    const itemIdToIndexMap = new Map();
+    itemIds.forEach((id, index) => {
+      itemIdToIndexMap.set(id.toString(), index);
+    });
+
+    return itemIdToIndexMap;
+  };
+
+  piling.set('pileOrderItems', pileOrderItems);
+  ```
+
+  The signature of the callback function is as follows:
+
+  ```javascript
+    function (pileState) {
+      // Sort item ids and create a map
+      return itemIdToIndexMap;
+    }
+  ```
+
 - `pileItemOffset` can be set to an array or a callback function. The array should be a tuple specifying the x and y offset in pixel. E.g.,
 
   ```javascript
@@ -628,32 +655,6 @@ Unsubscribe from an event. See [events](#events) for all the events.
   The function should return a value within `[0, 1]`.
 
 - The default value of `previewBackgroundColor` and `previewBackgroundOpacity` is `'inherit'`, which means that their value inherits from `pileBackgroundColor` and `pileBackgroundOpacity`. If you want preview's background color to be different from pile's, you can set a specific color.
-
-- `pileItemOrder` is used to sort the items on a pile before positioning the items. It should be set to a callback function which will receive an array of all the [items](#stateitems) on the pile, and should return a `Map` that maps the item's id to its expected index after sorting. E.g.,
-
-  ```javascript
-  const pileItemOrder = itemStates => {
-    itemStates.sort((a, b) => a.id - b.id);
-
-    const itemIdToIndexMap = new Map();
-    itemStates.forEach((item, index) => {
-      itemIdToIndexMap.set(item.id.toString(), index);
-    });
-
-    return itemIdToIndexMap;
-  };
-
-  piling.set('pileItemOrder', pileItemOrder);
-  ```
-
-  The signature of the callback function is as follows:
-
-  ```javascript
-    function (itemStates) {
-      // Sort item states and create a map
-      return itemIdToIndexMap;
-    }
-  ```
 
 - `pileLabel` can be set to a `string`, `object`, `function`, or `array` of the previous types. E.g.,
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -594,20 +594,10 @@ Unsubscribe from an event. See [events](#events) for all the events.
   }
   ```
 
-- `pileOrderItems` is used to sort the items on a pile before positioning the items. It should be set to a callback function which will receive the current [pile](#statepiles), and should return a `Map` that maps the item's id to its expected index after sorting. E.g.,
+- `pileOrderItems` is used to sort the items on a pile before positioning the items. It should be set to a callback function which will receive the current [pile](#statepiles), and should return an array of sorted itemIDs. E.g.,
 
   ```javascript
-  const pileOrderItems = pileState => {
-    const itemIds = pileState.items;
-    itemIds.sort((a, b) => a - b);
-
-    const itemIdToIndexMap = new Map();
-    itemIds.forEach((id, index) => {
-      itemIdToIndexMap.set(id.toString(), index);
-    });
-
-    return itemIdToIndexMap;
-  };
+  const pileOrderItems = pileState => pileState.items.sort((a, b) => a - b);
 
   piling.set('pileOrderItems', pileOrderItems);
   ```
@@ -616,8 +606,8 @@ Unsubscribe from an event. See [events](#events) for all the events.
 
   ```javascript
     function (pileState) {
-      // Sort item ids and create a map
-      return itemIdToIndexMap;
+      // Sort itemIDs
+      return arrayOfSortedIds;
     }
   ```
 

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -143,15 +143,7 @@ const createMatrixPiles = async (element, darkMode) => {
     cellSize: 64,
     pileCellAlignment: 'center',
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5),
-    pileOrderItems: pileState => {
-      const itemIds = pileState.items;
-      itemIds.sort((a, b) => a - b);
-      const itemIdsMap = new Map();
-      itemIds.forEach((id, index) => {
-        itemIdsMap.set(id.toString(), index);
-      });
-      return itemIdsMap;
-    },
+    pileOrderItems: pileState => pileState.items.sort((a, b) => a - b),
     previewScaling: pile => [
       1,
       Math.max(0.1, 1 - (pile.items.length - 2) / 10)

--- a/examples/matrices.js
+++ b/examples/matrices.js
@@ -143,11 +143,12 @@ const createMatrixPiles = async (element, darkMode) => {
     cellSize: 64,
     pileCellAlignment: 'center',
     pileScale: pile => 1 + Math.min((pile.items.length - 1) * 0.05, 0.5),
-    pileItemOrder: itemStates => {
-      itemStates.sort((a, b) => a.id - b.id);
+    pileOrderItems: pileState => {
+      const itemIds = pileState.items;
+      itemIds.sort((a, b) => a - b);
       const itemIdsMap = new Map();
-      itemStates.forEach((item, index) => {
-        itemIdsMap.set(item.id.toString(), index);
+      itemIds.forEach((id, index) => {
+        itemIdsMap.set(id.toString(), index);
       });
       return itemIdsMap;
     },

--- a/examples/scatterplots.js
+++ b/examples/scatterplots.js
@@ -95,11 +95,7 @@ const createScatterplotPiles = async (element, darkMode = false) => {
       }
       return regionOrderIndex[a.region] - regionOrderIndex[b.region];
     });
-    const itemIdsMap = new Map();
-    itemStates.forEach((item, index) => {
-      itemIdsMap.set(item.id.toString(), index);
-    });
-    return itemIdsMap;
+    return itemStates.map(item => item.id);
   };
 
   const previewItemYOffset = d3.scaleLinear();

--- a/examples/scatterplots.js
+++ b/examples/scatterplots.js
@@ -85,7 +85,10 @@ const createScatterplotPiles = async (element, darkMode = false) => {
     height: previewHeight
   });
 
-  const pileItemOrder = itemStates => {
+  const pileOrderItems = pileState => {
+    const itemStates = pileState.items.map(itemId => {
+      return { ...items[itemId], id: itemId };
+    });
     itemStates.sort((a, b) => {
       if (a.region === b.region) {
         return a.year - b.year;
@@ -144,7 +147,7 @@ const createScatterplotPiles = async (element, darkMode = false) => {
     cellAlign: 'center',
     cellPadding: 9,
     cellAspectRatio,
-    pileItemOrder,
+    pileOrderItems,
     pileScale: () => cameraScale,
     previewItemOffset,
     previewScaling: pile => {

--- a/src/library.js
+++ b/src/library.js
@@ -1249,13 +1249,13 @@ const createPilingJs = (rootElement, initOptions = {}) => {
   const positionPilesDb = debounce(positionPiles, POSITION_PILES_DEBOUNCE_TIME);
 
   const positionItems = (pileId, { all = false } = {}) => {
-    const { items, pileItemOrder } = store.state;
+    const { piles, pileOrderItems } = store.state;
 
     const pileInstance = pileInstances.get(pileId);
 
-    if (isFunction(pileItemOrder)) {
-      const itemStates = pileInstance.items.map(item => items[item.id]);
-      pileInstance.setItemOrder(pileItemOrder(itemStates));
+    if (isFunction(pileOrderItems)) {
+      const pileState = piles[pileId];
+      pileInstance.setItemOrder(pileOrderItems(pileState));
     }
 
     pileInstance.positionItems(animator, { all });

--- a/src/pile.js
+++ b/src/pile.js
@@ -704,16 +704,21 @@ const createPile = (
     animator.add(tweener);
   };
 
-  const setItemOrder = itemIdsMap => {
+  const setItemOrder = itemIds => {
+    const itemIdToIndex = new Map();
+    itemIds.forEach((itemId, index) => {
+      itemIdToIndex.set(itemId.toString(), index);
+    });
+
     const sortFunc = index => (a, b) => {
       const id1 = index.get(a);
       const id2 = index.get(b);
-      return itemIdsMap.get(id1) - itemIdsMap.get(id2);
+      return itemIdToIndex.get(id1) - itemIdToIndex.get(id2);
     };
 
     normalItemContainer.children.sort(sortFunc(normalItemIdIndex));
     previewItemContainer.children.sort(sortFunc(previewItemIdIndex));
-    allItems.sort((a, b) => itemIdsMap.get(a.id) - itemIdsMap.get(b.id));
+    allItems.sort((a, b) => itemIdToIndex.get(a.id) - itemIdToIndex.get(b.id));
   };
 
   const positionPreviews = animator => {

--- a/src/store.js
+++ b/src/store.js
@@ -218,7 +218,7 @@ const [pileItemBrightness, setPileItemBrightness] = setter(
 const [pileItemInvert, setPileItemInvert] = setter('pileItemInvert', false);
 const [pileItemOffset, setPileItemOffset] = setter('pileItemOffset', [5, 5]);
 const [pileItemOpacity, setPileItemOpacity] = setter('pileItemOpacity', 1.0);
-const [pileItemOrder, setPileItemOrder] = setter('pileItemOrder');
+const [pileOrderItems, setPileOrderItems] = setter('pileOrderItems');
 const [pileItemRotation, setPileItemRotation] = setter('pileItemRotation', 0);
 const [pileItemTint, setPileItemTint] = setter(
   'pileItemTint',
@@ -643,7 +643,7 @@ const createStore = () => {
     pileItemBrightness,
     pileItemInvert,
     pileItemOpacity,
-    pileItemOrder,
+    pileOrderItems,
     pileItemRotation,
     pileItemTint,
     pileLabel,
@@ -805,7 +805,7 @@ export const createAction = {
   setPileCoverInvert,
   setPileCoverScale,
   setPileItemOffset,
-  setPileItemOrder,
+  setPileOrderItems,
   setPileItemBrightness,
   setPileItemInvert,
   setPileItemOpacity,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Rename `pileItemOrder` to `pileOrderItems` to make it a pile property

> Why is it necessary?

Fixes #192 

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [x] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
