### PR TITLE
Flekschas/init from state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Next
 
-- Add `createPilingJsFromState` as a named export to simplify the initialization of a piling.js instance from an existing state.
+- Add `createLibraryFromState` as a named export to simplify the initialization of a piling.js instance from an existing state.
 - Allow subsampling of previews
 - Allow initializing from previous state using `createPilingJs(element, { ... }, { initFromState: true })`
 - Return promise when running `importState()` that resolves once piling.js' state was overridden.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### Next
 
+- Add `createPilingJsFromState` as a named export to simplify the initialization of a piling.js instance from an existing state.
 - Allow subsampling of previews
 - Allow initializing from previous state using `createPilingJs(element, { ... }, { initFromState: true })`
+- Return promise when running `importState()` that resolves once piling.js' state was overridden.
 
 _[Changes since v0.7.3](https://github.com/flekschas/piling.js/compare/v0.7.3...master)_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next
 
 - Allow subsampling of previews
+- Allow initializing from previous state using `createPilingJs(element, { ... }, { initFromState: true })`
 
 _[Changes since v0.7.3](https://github.com/flekschas/piling.js/compare/v0.7.3...master)_
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -158,7 +158,7 @@ An array of objects with one required property `src` and other optional user-def
 
 ## Constructors
 
-### createPilingJs(_domElement_, _initialProperties_)
+### createLibrary(_domElement_, _initialProperties_)
 
 **Arguments:**
 
@@ -167,7 +167,7 @@ An array of objects with one required property `src` and other optional user-def
 
 **Returns:** a new piling instance.
 
-### createPilingJsFromState(_domElement_, _initialProperties_)
+### createLibraryFromState(_domElement_, _initialProperties_)
 
 **Arguments:**
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -158,14 +158,16 @@ An array of objects with one required property `src` and other optional user-def
 
 ## Constructor
 
-#### `const piling = createPilingJs(domElement, options = {});`
-
-**Returns:** a new piling instance.
+#### `const piling = createPilingJs(domElement, properties = {}, options = {});`
 
 **Arguments:**
 
 - `domElement`: reference to the DOM element that will host piling.js' canvas
-- `options` (optional): an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for configuration. The [supported properties](#pilingsetproperty-value) are the same as for [`set()`](#pilingsetproperty-value).
+- `properties` (optional): an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for setting initil view properties. The [supported properties](#pilingsetproperty-value) are the same as for [`set()`](#pilingsetproperty-value).
+- `options` (optional): an an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for additional configuration:
+  - `initFromState`: if `true` piling.js will treat `properties` as a complete state and import it using [`importState()`](#pilingimportstatestate) rather than initializing the state from scratch.
+
+**Returns:** a new piling instance.
 
 ## Methods
 
@@ -389,6 +391,16 @@ const eventHandler = (eventData) => {
 #### `piling.unsubscribe(eventName, eventHandler)`
 
 Unsubscribe from an event. See [events](#events) for all the events.
+
+#### `piling.exportState()`
+
+**Returns:** current state object.
+
+#### `piling.importState(state)`
+
+**Arguments:**
+
+- `state`: Previously exported state object.
 
 ## Properties
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -156,33 +156,40 @@ An array of objects with one required property `src` and other optional user-def
 
 # Library
 
-## Constructor
+## Constructors
 
-#### `const piling = createPilingJs(domElement, properties = {}, options = {});`
+### createPilingJs(_domElement_, _initialProperties_)
 
 **Arguments:**
 
 - `domElement`: reference to the DOM element that will host piling.js' canvas
-- `properties` (optional): an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for setting initil view properties. The [supported properties](#pilingsetproperty-value) are the same as for [`set()`](#pilingsetproperty-value).
-- `options` (optional): an an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for additional configuration:
-  - `initFromState`: if `true` piling.js will treat `properties` as a complete state and import it using [`importState()`](#pilingimportstatestate) rather than initializing the state from scratch.
+- `initialProperties` (optional): an [options object](https://www.codereadability.com/what-are-javascript-options-objects/) for setting initil view properties. The [supported properties](#pilingsetproperty-value) are the same as for [`set()`](#pilingsetproperty-value).
 
 **Returns:** a new piling instance.
 
+### createPilingJsFromState(_domElement_, _initialProperties_)
+
+**Arguments:**
+
+- `domElement`: reference to the DOM element that will host piling.js' canvas
+- `state`: a complete state object obtained from [`exportState()`](#pilingexportstate).
+
+**Returns:** a promise resolving to the new piling instance once the state was imported.
+
 ## Methods
 
-#### `piling.get(property)`
+### piling.get(_property_)
 
-**Returns:** one of the properties documented in [`set()`](#pilingsetproperty-value)
+**Returns:** one of the properties documented in [`set()`](#piling.set)
 
-#### `piling.set(property, value)`
+### piling.set(_property_, _value_)
 
 **Arguments:**
 
 - `property`: Either a string defining the [property](#properties) to be set or an object defining key-value pairs to set multiple [properties](#properties) at once.
 - `value`: If `property` is a string, `value` is the corresponding value. Otherwise, `value` is ignored.
 
-#### `piling.arrangeBy(type, objective, options)`
+### piling.arrangeBy(_type_, _objective_, _options_)
 
 Position piles with user-specified arrangement method.
 
@@ -310,7 +317,7 @@ The following options are available for all types:
     piling.arrangeBy('data', ['a', 'b', 'c'], { runDimReductionOnPiles: true });
     ```
 
-#### `piling.groupBy(type, objective, options)`
+### piling.groupBy(_type_, _objective_, _options_)
 
 Programmatically group items and piles based on the layout, spatial proximity, or data together.
 
@@ -356,27 +363,31 @@ piling.groupBy('cluster', 'x', { clusterer: dbscan }); // Same as above but with
 piling.groupBy('cluster', 'x', { clustererOptions: { k: 2 } }); // Same as above but with customized clusterer options
 ```
 
-#### `piling.destroy()`
+### piling.destroy()
 
 Destroys the piling instance by disposing all event listeners, the pubSub instance, canvas, and the root PIXI container.
 
-#### `piling.halt({ text, spinner = true })`
+### piling.halt(_options_)
 
 This will display a popup across the entire piling.js element to temporarily block all interactions. This is useful if you are doing some asynchronous job outside piling and want to prevent user interactions.
 
-#### `piling.render()`
+**Arguments:**
+
+- `options` (optional): Object with the two properties: `text` and `spinner` (default `true`)
+
+### piling.render()
 
 Render the root PIXI container.
 
-#### `piling.resume()`
+### piling.resume()
 
 This will the halting popup.
 
-#### `piling.splitAll()`
+### piling.splitAll()
 
 Scatter all the piles at the same time.
 
-#### `piling.subscribe(eventName, eventHandler)`
+### piling.subscribe(_eventName_, _eventHandler_)
 
 Subscribe to an event.
 `eventName` needs to be one of these [events](#events).
@@ -388,19 +399,21 @@ const eventHandler = (eventData) => {
 };
 ```
 
-#### `piling.unsubscribe(eventName, eventHandler)`
+### piling.unsubscribe(_eventName_, _eventHandler_)
 
 Unsubscribe from an event. See [events](#events) for all the events.
 
-#### `piling.exportState()`
+### piling.exportState()
 
 **Returns:** current state object.
 
-#### `piling.importState(state)`
+### piling.importState(_state_)
 
 **Arguments:**
 
 - `state`: Previously exported state object.
+
+**Returns:** a promise that resolves once the state was imported
 
 ## Properties
 
@@ -839,6 +852,8 @@ A list of objects with the following properties:
 ]
 ```
 
+---
+
 # Renderers
 
 A renderer should be a function that takes as input an array of the value of `src` property in your data that determining the source, and outputs promises which resolve to [Pixi Texture objects](http://pixijs.download/release/docs/PIXI.Texture.html).
@@ -1038,6 +1053,8 @@ piling.set('coverRenderer', coverRenderer);
 piling.set('previewRenderer', previewRenderer);
 ```
 
+---
+
 # Aggregators
 
 Aggregators are used to aggregate items.
@@ -1153,6 +1170,8 @@ It's important that the number of items and number of aggregated previews match,
 otherwise piling.js wouldn't be able to match the previews to their associated
 item.
 
+---
+
 # Dimensionality Reducers
 
 A dimensionality reducer is a transformation function that that reduced multi-dimensional input data down to two normalized dimension.
@@ -1211,7 +1230,11 @@ Call [set](#pilingsetproperty-value) method to add aggregators to the library.
 piling.set('dimensionalityReducer', umap);
 ```
 
+---
+
 # Clusterers
+
+---
 
 # Interactions
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,7 +9,7 @@
 
 - [**Library**](/docs/?id=library)
 
-  - [Constructor](/docs/?id=constructor)
+  - [Constructors](/docs/?id=constructors)
   - [Methods](/docs/?id=methods)
   - [Properties](/docs/?id=properties)
   - [Events](/docs/?id=events)

--- a/docs/index.html
+++ b/docs/index.html
@@ -105,6 +105,45 @@
         margin: 1em 0 0;
       }
 
+      .markdown-section h1:before {
+        content: '';
+        display: block;
+        padding-bottom: 0.5rem;
+        border-top: 2px solid var(--theme-color);
+      }
+
+      .markdown-section h1:first-child:before {
+        display: none;
+      }
+
+      .markdown-section h2:before {
+        content: '';
+        display: block;
+        padding-bottom: 0.25rem;
+        border-top: 1px solid var(--mono-shade3);
+      }
+
+      .markdown-section h2:first-child:before {
+        display: none;
+      }
+
+      .markdown-section h3 {
+        position: relative;
+      }
+
+      .markdown-section h3:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: -1rem;
+        margin-top: -0.25rem;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 0.5rem;
+        background: var(--mono-shade3);
+      }
+
       #external-links a {
         color: var(--mono-tint1);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,9 +1391,9 @@
       }
     },
     "@flekschas/utils": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.23.0.tgz",
-      "integrity": "sha512-RN1pQwFzRUjuigHal6S/+t/muI2kU4n/sNU4qH3CeLXjbXHyCjNg3ZHGNEyuJCEGCTqzeyYNT3SiB8YZUA+nfw=="
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.23.1.tgz",
+      "integrity": "sha512-miAac7yeMj1qZflakFdvypXJH967wIzutBD9Rb/IeSX6pUOVoAeeIvNrbj5PK0QoLkwZvbhJIInJTHvVTwc0bQ=="
     },
     "@npmcli/ci-detect": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@flekschas/utils": "~0.23.0",
+    "@flekschas/utils": "~0.23.1",
     "camera-2d-simple": "~2.2.0",
     "deep-equal": "~1.1.0",
     "dom-2d-camera": "~1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -17,4 +17,13 @@ export {
 
 export { default as createLibrary } from './library';
 
+export const createPilingJsFromState = (element, state) =>
+  new Promise((resolve) => {
+    const piling = createPilingJs(element);
+    piling.subscribe(async () => {
+      await piling.importState(state);
+      resolve(piling);
+    }, 1);
+  });
+
 export default createPilingJs;

--- a/src/index.js
+++ b/src/index.js
@@ -17,13 +17,10 @@ export {
 
 export { default as createLibrary } from './library';
 
-export const createPilingJsFromState = (element, state) =>
-  new Promise((resolve) => {
-    const piling = createPilingJs(element);
-    piling.subscribe(async () => {
-      await piling.importState(state);
-      resolve(piling);
-    }, 1);
-  });
+export const createLibraryFromState = async (element, state) => {
+  const piling = createPilingJs(element);
+  await piling.importState(state);
+  return piling;
+};
 
 export default createPilingJs;

--- a/src/library.js
+++ b/src/library.js
@@ -95,11 +95,7 @@ const EXTRA_ROWS = 3;
 
 const l2RectDist = lRectDist(2);
 
-const createPilingJs = (
-  rootElement,
-  initProps = {},
-  { initFromState = false } = {}
-) => {
+const createPilingJs = (rootElement, initProps = {}) => {
   const scrollContainer = document.createElement('div');
   scrollContainer.className = 'pilingjs-scroll-container';
   const scrollEl = document.createElement('div');
@@ -5137,15 +5133,10 @@ const createPilingJs = (
     enableScrolling();
     enableInteractivity();
 
-    if (initFromState) {
-      isInitialPositioning = false;
-      importState(initProps, true);
-    } else {
-      setPublic(initProps);
+    setPublic(initProps);
 
-      if (!initProps.piles && initProps.items) {
-        store.dispatch(createAction.initPiles(initProps.items));
-      }
+    if (!initProps.piles && initProps.items) {
+      store.dispatch(createAction.initPiles(initProps.items));
     }
   };
 

--- a/src/library.js
+++ b/src/library.js
@@ -4027,8 +4027,20 @@ const createPilingJs = (
   const exportState = () => store.export();
 
   const importState = (newState, overwriteState = false) => {
+    // We assume that the user imports an already initialized state
+    isInitialPositioning = false;
+    let updateUnsubscriber;
+    const whenUpdated = new Promise((resolve) => {
+      updateUnsubscriber = pubSub.subscribe('update', ({ action }) => {
+        if (action.type.indexOf('OVERWRITE') >= 0) resolve();
+      });
+    });
     store.import(newState, overwriteState);
     resetPileBorder();
+    whenUpdated.then(() => {
+      pubSub.unsubscribe(updateUnsubscriber);
+    });
+    return whenUpdated;
   };
 
   const expandProperty = (objective) => {

--- a/src/library.js
+++ b/src/library.js
@@ -95,7 +95,11 @@ const EXTRA_ROWS = 3;
 
 const l2RectDist = lRectDist(2);
 
-const createPilingJs = (rootElement, initOptions = {}) => {
+const createPilingJs = (
+  rootElement,
+  initProps = {},
+  { initFromState = false } = {}
+) => {
   const scrollContainer = document.createElement('div');
   scrollContainer.className = 'pilingjs-scroll-container';
   const scrollEl = document.createElement('div');
@@ -964,9 +968,11 @@ const createPilingJs = (rootElement, initOptions = {}) => {
 
     createRBush();
 
-    store.state.focusedPiles.forEach((focusedPile) => {
-      pileInstances.get(focusedPile).focus();
-    });
+    store.state.focusedPiles
+      .filter((pileId) => pileInstances.has(pileId))
+      .forEach((pileId) => {
+        pileInstances.get(pileId).focus();
+      });
 
     updateScrollHeight();
     renderRaf();
@@ -1120,9 +1126,15 @@ const createPilingJs = (rootElement, initOptions = {}) => {
           const newItem = createItem({ id, image, pubSub }, { preview });
 
           renderedItems.set(id, newItem);
-
+        });
+        // We cannot combine the two loops as we might have initialized
+        // piling.js with a predefined pile state. In that case a pile of
+        // with a lower index might rely on an item with a higher index that
+        // hasn't been created yet.
+        renderedImages.forEach((image, index) => {
+          const id = newItemIds[index];
           const pileState = piles[id];
-          createPileHandler(id, pileState);
+          if (pileState.items.length) createPileHandler(id, pileState);
         });
         scaleItems();
         renderRaf();
@@ -1392,6 +1404,8 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     const { piles, pileOrderItems } = store.state;
 
     const pileInstance = pileInstances.get(pileId);
+
+    if (!pileInstance) return;
 
     if (isFunction(pileOrderItems)) {
       const pileState = piles[pileId];
@@ -5111,7 +5125,16 @@ const createPilingJs = (rootElement, initOptions = {}) => {
     enableScrolling();
     enableInteractivity();
 
-    setPublic(initOptions);
+    if (initFromState) {
+      isInitialPositioning = false;
+      importState(initProps, true);
+    } else {
+      setPublic(initProps);
+
+      if (!initProps.piles && initProps.items) {
+        store.dispatch(createAction.initPiles(initProps.items));
+      }
+    }
   };
 
   const destroy = () => {

--- a/src/store.js
+++ b/src/store.js
@@ -462,6 +462,20 @@ const setItems = (newItems) => ({
 
 const piles = (previousState = {}, action) => {
   switch (action.type) {
+    case 'SET_PILES': {
+      return Object.entries(action.payload.piles).reduce(
+        (newState, [pileId, pileState], index) => {
+          newState[pileId] = {
+            ...pileState,
+            id: pileId,
+            index: Number.isNaN(+pileState.index) ? index : +pileState.index,
+          };
+          return newState;
+        },
+        {}
+      );
+    }
+
     case 'INIT_PILES': {
       const useCustomItemId = action.payload.newItems.length
         ? typeof action.payload.newItems[0].id !== 'undefined'
@@ -636,6 +650,11 @@ const scatterPiles = (pilesToBeScattered) => ({
 const splitPiles = (pilesToBeSplit) => ({
   type: 'SPLIT_PILES',
   payload: { piles: pilesToBeSplit },
+});
+
+const setPiles = (newPiles) => ({
+  type: 'SET_PILES',
+  payload: { piles: newPiles },
 });
 
 const [showSpatialIndex, setShowSpatialIndex] = setter(
@@ -823,6 +842,7 @@ export const createAction = {
   mergePiles,
   movePiles,
   scatterPiles,
+  setPiles,
   setCoverRenderer,
   setArrangementObjective,
   setArrangeOnGrouping,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env, argv) => ({
   devServer: {
     contentBase: './examples',
   },
+  devtool: 'eval-cheap-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Added a set reducer to allow to directly set piles.
- Added `initFromState` to the library constructor to allow initializing from a previous state as follows:

```javascript
  const prevState = JSON.parse(window.sessionStorage.getItem('pilingjs'));

  const piling = createPilingJs(
    element,
    {
      ...(prevState || {}),
      items,
      itemRenderer: renderer,
    },
    { initFromState: !!prevState }
  );
```

> Why is it necessary?

To simplify initializing from a previous state

## Checklist

- [x] GitHub labels properly set (e.g., bug, new feature, etc.)
- [x] Documentation added or updated
- [ ] Examples added or updated
- [ ] Screenshot or GIF included (e.g. new or changed visualization features)
- [x] CHANGELOG.md updated
